### PR TITLE
Fix schema $ref issue

### DIFF
--- a/swagger-to-har.js
+++ b/swagger-to-har.js
@@ -146,6 +146,12 @@ var getQueryStrings = function (swagger, path, method, values) {
         /^#/.test(param['$ref'])) {
         param = resolveRef(swagger, param['$ref'])
       }
+      if (typeof param.schema !== 'undefined') {
+        if (typeof param.schema['$ref'] === 'string' &&
+          /^#/.test(param.schema['$ref'])) {
+          param.schema = resolveRef(swagger, param.schema['$ref'])
+        }
+      }
       if (typeof param.in !== 'undefined' && param.in.toLowerCase() === 'query') {
         queryStrings.push({
           name: param.name,


### PR DESCRIPTION
Fix for issue:
https://github.com/ErikWittern/swagger-snippet/issues/26

---
```
TypeError: Cannot read property 'toUpperCase' of undefined
    at getQueryStrings (/node_modules/swagger-snippet/swagger-to-har.js:154:62)
    at createHar (/node_modules/swagger-snippet/swagger-to-har.js:44:18)
```
for spec:
```
      parameters:
        - in: "query"
          name: "param_name"
          description: "param description."
          schema:
            $ref: "#/components/schemas/SomeComponent"
```
