### PR TITLE
Update apikey security handling

### DIFF
--- a/openapi-to-har.js
+++ b/openapi-to-har.js
@@ -256,7 +256,11 @@ const getHeadersArray = function (openApi, path, method) {
       const secScheme = Object.keys(openApi.security[m])[0]
       const secDefinition = openApi.components.securitySchemes[secScheme];
       const authType = secDefinition.type.toLowerCase();
-      let authScheme = secDefinition.scheme.toLowerCase();
+      if(authType !== 'apikey'){
+        let authScheme = secDefinition.scheme.toLowerCase();
+      } else {
+        let authScheme = null;
+      }
       switch (authType) {
         case 'http':
           switch(authScheme){

--- a/openapi-to-har.js
+++ b/openapi-to-har.js
@@ -256,11 +256,12 @@ const getHeadersArray = function (openApi, path, method) {
       const secScheme = Object.keys(openApi.security[m])[0]
       const secDefinition = openApi.components.securitySchemes[secScheme];
       const authType = secDefinition.type.toLowerCase();
+      let authScheme = null;
+      
       if(authType !== 'apikey'){
         let authScheme = secDefinition.scheme.toLowerCase();
-      } else {
-        let authScheme = null;
       }
+      
       switch (authType) {
         case 'http':
           switch(authScheme){

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openapi-snippet",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "Generates code snippets from Open API (previously Swagger) documents.",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Per OAS documentation - apikey does not require a scheme property, hence this code fails:
```
 let authScheme = secDefinition.scheme.toLowerCase();
                                            ^
TypeError: Cannot read property 'toLowerCase' of undefined