### PR TITLE
OpenAPI 3.0 securitySchemes fix for oauth2

### DIFF
--- a/openapi-to-har.js
+++ b/openapi-to-har.js
@@ -283,7 +283,7 @@ const getHeadersArray = function (openApi, path, method) {
       const authType = secDefinition.type.toLowerCase();
       let authScheme = null;
       
-      if(authType !== 'apikey'){
+      if(authType !== 'apikey' && authType !== 'oauth2'){
         authScheme = secDefinition.scheme.toLowerCase();
       }
       


### PR DESCRIPTION
Fix for securitySchemes validations in OpenAPI 3.0 for type "oauth2"
Ref: https://swagger.io/docs/specification/authentication/oauth2/

For OAS: 
"securitySchemes": {
      "oauth2": {
        "type": "oauth2",
        "flows": { }
        }
      }
This causes the code to fail at:
"authScheme = secDefinition.scheme.toLowerCase();" as scheme doesn't exist for type oauth2.
Thereby, causing 'Cannot call method 'toLowerCase' of **undefined**'.
