### PR TITLE
Replace constant declaration for variable with let

### DIFF
--- a/index.js
+++ b/index.js
@@ -151,7 +151,7 @@ const getResourceName = function (urlStr) {
 const formatTarget = function (targetStr) {
   const language = targetStr.split('_')[0]
   const title = capitalizeFirstLetter(language)
-  const library = targetStr.split('_')[1]
+  let library = targetStr.split('_')[1]
 
   const validTargets = HTTPSnippet.availableTargets()
   let validLanguage = false


### PR DESCRIPTION
"library" in L154 was declared as const, and possibly reassigned at L164 which resulted in a TypeError

This PR simply declares `library` with a `let` instead of a `const`.