### PR TITLE
add support for using the parameter.example property to generate the …

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,3 @@
+dist
+*.yml
+*.md

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,3 @@
+{
+  "singleQuote": true
+}

--- a/index.js
+++ b/index.js
@@ -6,10 +6,10 @@
  * Author: Erik Wittern
  * License: MIT
  */
-'use strict'
+'use strict';
 
-const OpenAPIToHar = require('./openapi-to-har.js')
-const HTTPSnippet = require('httpsnippet')
+const OpenAPIToHar = require('./openapi-to-har.js');
+const HTTPSnippet = require('httpsnippet');
 
 /**
  * Return snippets for endpoint identified using path and method in the given
@@ -18,29 +18,32 @@ const HTTPSnippet = require('httpsnippet')
  * @param {object} openApi  OpenAPI document
  * @param {string} path     Path identifying endpoint, e.g., '/users'
  * @param {string} method   HTTP method identifying endpoint, e.g., 'get'
- * @param {array} targets   List of languages to create snippets in, e.g, 
+ * @param {array} targets   List of languages to create snippets in, e.g,
  *                          ['cURL', 'Node']
  * @param {object} values   Optional: Values for the query parameters if present
  */
 const getEndpointSnippets = function (openApi, path, method, targets, values) {
   // if optional parameter is not provided, set it to empty object
   if (typeof values === 'undefined') {
-    values = {}
+    values = {};
   }
 
-  const har = OpenAPIToHar.getEndpoint(openApi, path, method, values)
+  const har = OpenAPIToHar.getEndpoint(openApi, path, method, values);
 
-  const snippet = new HTTPSnippet(har)
+  const snippet = new HTTPSnippet(har);
 
-  const snippets = []
+  const snippets = [];
   for (let j in targets) {
-    const target = formatTarget(targets[j])
-    if (!target) throw new Error('Invalid target: ' + targets[j])
+    const target = formatTarget(targets[j]);
+    if (!target) throw new Error('Invalid target: ' + targets[j]);
     snippets.push({
       id: targets[j],
       title: target.title,
-      content: snippet.convert(target.language, typeof target.library !== 'undefined' ? target.library : null)
-    })
+      content: snippet.convert(
+        target.language,
+        typeof target.library !== 'undefined' ? target.library : null
+      ),
+    });
   }
 
   return {
@@ -48,35 +51,38 @@ const getEndpointSnippets = function (openApi, path, method, targets, values) {
     url: har.url,
     description: har.description,
     resource: getResourceName(har.url),
-    snippets: snippets
-  }
-}
+    snippets: snippets,
+  };
+};
 
 /**
  * Return snippets for all endpoints in the given OpenAPI document.
- * 
+ *
  * @param {object} openApi  OpenAPI document
- * @param {array} targets   List of languages to create snippets in, e.g, 
+ * @param {array} targets   List of languages to create snippets in, e.g,
  *                          ['cURL', 'Node']
  */
 const getSnippets = function (openApi, targets) {
-  const harList = OpenAPIToHar.getAll(openApi)
+  const harList = OpenAPIToHar.getAll(openApi);
 
-  const results = []
+  const results = [];
   for (let i in harList) {
     // create HTTPSnippet object:
-    const har = harList[i]
-    const snippet = new HTTPSnippet(har.har)
+    const har = harList[i];
+    const snippet = new HTTPSnippet(har.har);
 
-    const snippets = []
+    const snippets = [];
     for (let j in targets) {
-      const target = formatTarget(targets[j])
-      if (!target) throw new Error('Invalid target: ' + targets[j])
+      const target = formatTarget(targets[j]);
+      if (!target) throw new Error('Invalid target: ' + targets[j]);
       snippets.push({
         id: targets[j],
         title: target.title,
-        content: snippet.convert(target.language, typeof target.library !== 'undefined' ? target.library : null)
-      })
+        content: snippet.convert(
+          target.language,
+          typeof target.library !== 'undefined' ? target.library : null
+        ),
+      });
     }
 
     results.push({
@@ -84,23 +90,23 @@ const getSnippets = function (openApi, targets) {
       url: har.url,
       description: har.description,
       resource: getResourceName(har.url),
-      snippets
-    })
+      snippets,
+    });
   }
 
   // sort results:
   results.sort((a, b) => {
     if (a.resource < b.resource) {
-      return -1
+      return -1;
     } else if (a.resource > b.resource) {
-      return 1
+      return 1;
     } else {
-      return getMethodOrder(a.method.toLowerCase(), b.method.toLowerCase())
+      return getMethodOrder(a.method.toLowerCase(), b.method.toLowerCase());
     }
-  })
+  });
 
-  return results
-}
+  return results;
+};
 
 /**
  * Determine the order of HTTP methods.
@@ -110,19 +116,19 @@ const getSnippets = function (openApi, targets) {
  * @return {number}   The order instruction for the given HTTP verbs
  */
 const getMethodOrder = function (a, b) {
-  const order = ['get', 'post', 'put', 'delete', 'patch']
+  const order = ['get', 'post', 'put', 'delete', 'patch'];
   if (order.indexOf(a) === -1) {
-    return 1
+    return 1;
   } else if (order.indexOf(b) === -1) {
-    return -1
+    return -1;
   } else if (order.indexOf(a) < order.indexOf(b)) {
-    return -1
+    return -1;
   } else if (order.indexOf(a) > order.indexOf(b)) {
-    return 1
+    return 1;
   } else {
-    return 0
+    return 0;
   }
-}
+};
 
 /**
  * Determines the name of the resource exposed by the method.
@@ -132,14 +138,14 @@ const getMethodOrder = function (a, b) {
  * @return {string}        The determined resource name
  */
 const getResourceName = function (urlStr) {
-  const pathComponents = urlStr.split('/')
+  const pathComponents = urlStr.split('/');
   for (let i = pathComponents.length - 1; i >= 0; i--) {
-    const cand = pathComponents[i]
+    const cand = pathComponents[i];
     if (cand !== '' && !/^{/.test(cand)) {
-      return cand
+      return cand;
     }
   }
-}
+};
 
 /**
  * Format the given target by splitting up language and library and making sure
@@ -149,26 +155,26 @@ const getResourceName = function (urlStr) {
  * @return {object}           Object with formatted target, or null
  */
 const formatTarget = function (targetStr) {
-  const language = targetStr.split('_')[0]
-  const title = capitalizeFirstLetter(language)
-  let library = targetStr.split('_')[1]
+  const language = targetStr.split('_')[0];
+  const title = capitalizeFirstLetter(language);
+  let library = targetStr.split('_')[1];
 
-  const validTargets = HTTPSnippet.availableTargets()
-  let validLanguage = false
-  let validLibrary = false
+  const validTargets = HTTPSnippet.availableTargets();
+  let validLanguage = false;
+  let validLibrary = false;
   for (let i in validTargets) {
-    const target = validTargets[i]
+    const target = validTargets[i];
     if (language === target.key) {
-      validLanguage = true
+      validLanguage = true;
       if (typeof library === 'undefined') {
-        library = target.default
-        validLibrary = true
+        library = target.default;
+        validLibrary = true;
       } else {
         for (let j in target.clients) {
-          const client = target.clients[j]
+          const client = target.clients[j];
           if (library === client.key) {
-            validLibrary = true
-            break
+            validLibrary = true;
+            break;
           }
         }
       }
@@ -176,37 +182,40 @@ const formatTarget = function (targetStr) {
   }
 
   if (!validLanguage || !validLibrary) {
-    return null
+    return null;
   }
 
   return {
-    title: typeof library !== 'undefined' ? title + ' + ' + capitalizeFirstLetter(library) : title,
+    title:
+      typeof library !== 'undefined'
+        ? title + ' + ' + capitalizeFirstLetter(library)
+        : title,
     language,
-    library
-  }
-}
+    library,
+  };
+};
 
 const capitalizeFirstLetter = function (string) {
-  return string.charAt(0).toUpperCase() + string.slice(1)
-}
+  return string.charAt(0).toUpperCase() + string.slice(1);
+};
 
 module.exports = {
   getSnippets,
-  getEndpointSnippets
-}
+  getEndpointSnippets,
+};
 
 // The if is only for when this is run from the browser
 if (typeof window !== 'undefined') {
   // grab existing namespace object, or create a blank object
   // if it doesn't exist
-  let OpenAPISnippets = window.OpenAPISnippets || {}
+  let OpenAPISnippets = window.OpenAPISnippets || {};
 
   // define that object
   OpenAPISnippets = {
     getSnippets,
-    getEndpointSnippets
-  }
+    getEndpointSnippets,
+  };
 
   // replace/create the global namespace
-  window.OpenAPISnippets = OpenAPISnippets
+  window.OpenAPISnippets = OpenAPISnippets;
 }

--- a/openapi-to-har.js
+++ b/openapi-to-har.js
@@ -18,7 +18,7 @@
  *   "comment" : ""
  * }
  */
-const OpenAPISampler = require('openapi-sampler')
+const OpenAPISampler = require('openapi-sampler');
 
 /**
  * Create HAR Request object for path and method pair described in given OpenAPI
@@ -33,10 +33,10 @@ const OpenAPISampler = require('openapi-sampler')
 const createHar = function (openApi, path, method, queryParamValues) {
   // if the operational parameter is not provided, set it to empty object
   if (typeof queryParamValues === 'undefined') {
-    queryParamValues = {}
+    queryParamValues = {};
   }
 
-  const baseUrl = getBaseUrl(openApi)
+  const baseUrl = getBaseUrl(openApi, path, method);
 
   const har = {
     method: method.toUpperCase(),
@@ -46,15 +46,15 @@ const createHar = function (openApi, path, method, queryParamValues) {
     httpVersion: 'HTTP/1.1',
     cookies: [],
     headersSize: 0,
-    bodySize: 0
-  }
+    bodySize: 0,
+  };
 
   // get payload data, if available:
-  const postData = getPayload(openApi, path, method)
-  if (postData) har.postData = postData
+  const postData = getPayload(openApi, path, method);
+  if (postData) har.postData = postData;
 
-  return har
-}
+  return har;
+};
 
 /**
  * Get the payload definition for the given endpoint (path + method) from the
@@ -69,38 +69,59 @@ const createHar = function (openApi, path, method, queryParamValues) {
 const getPayload = function (openApi, path, method) {
   if (typeof openApi.paths[path][method].parameters !== 'undefined') {
     for (let i in openApi.paths[path][method].parameters) {
-      const param = openApi.paths[path][method].parameters[i]
-      if (typeof param.in !== 'undefined' && param.in.toLowerCase() === 'body' &&
-        typeof param.schema !== 'undefined') {
-          try {
-            const sample = OpenAPISampler.sample(param.schema, {skipReadOnly: true}, openApi)
-            return {
-              mimeType: 'application/json',
-              text: JSON.stringify(sample)
-            }
-          } catch (err) {
-            console.log(err)
-            return null
-          }
+      const param = openApi.paths[path][method].parameters[i];
+      if (
+        typeof param.in !== 'undefined' &&
+        param.in.toLowerCase() === 'body' &&
+        typeof param.schema !== 'undefined'
+      ) {
+        try {
+          const sample = OpenAPISampler.sample(
+            param.schema,
+            { skipReadOnly: true },
+            openApi
+          );
+          return {
+            mimeType: 'application/json',
+            text: JSON.stringify(sample),
+          };
+        } catch (err) {
+          console.log(err);
+          return null;
+        }
       }
     }
   }
-  
-  if (openApi.paths[path][method].requestBody && openApi.paths[path][method].requestBody['$ref']) {
-    openApi.paths[path][method].requestBody = resolveRef(openApi, openApi.paths[path][method].requestBody['$ref']);
+
+  if (
+    openApi.paths[path][method].requestBody &&
+    openApi.paths[path][method].requestBody['$ref']
+  ) {
+    openApi.paths[path][method].requestBody = resolveRef(
+      openApi,
+      openApi.paths[path][method].requestBody['$ref']
+    );
   }
 
-    if (openApi.paths[path][method].requestBody && openApi.paths[path][method].requestBody.content &&
-        openApi.paths[path][method].requestBody.content['application/json'] &&
-        openApi.paths[path][method].requestBody.content['application/json'].schema) {
-        const sample = OpenAPISampler.sample(openApi.paths[path][method].requestBody.content['application/json'].schema, {skipReadOnly: true}, openApi)
-        return {
-            mimeType: 'application/json',
-            text: JSON.stringify(sample)
-        }
-    }
-  return null
-}
+  if (
+    openApi.paths[path][method].requestBody &&
+    openApi.paths[path][method].requestBody.content &&
+    openApi.paths[path][method].requestBody.content['application/json'] &&
+    openApi.paths[path][method].requestBody.content['application/json'].schema
+  ) {
+    const sample = OpenAPISampler.sample(
+      openApi.paths[path][method].requestBody.content['application/json']
+        .schema,
+      { skipReadOnly: true },
+      openApi
+    );
+    return {
+      mimeType: 'application/json',
+      text: JSON.stringify(sample),
+    };
+  }
+  return null;
+};
 
 /**
  * Gets the base URL constructed from the given openApi.
@@ -108,23 +129,49 @@ const getPayload = function (openApi, path, method) {
  * @param  {Object} openApi OpenAPI document
  * @return {string}         Base URL
  */
-const getBaseUrl = function (openApi) {
-  if (openApi.servers)
-      return openApi.servers[0].url
-  let baseUrl = ''
+const getBaseUrl = function (openApi, path, method) {
+  if (openApi.paths[path][method].servers)
+    return openApi.paths[path][method].servers[0].url;
+  if (openApi.paths[path].servers) return openApi.paths[path].servers[0].url;
+  if (openApi.servers) return openApi.servers[0].url;
+
+  let baseUrl = '';
   if (typeof openApi.schemes !== 'undefined') {
-    baseUrl += openApi.schemes[0]
+    baseUrl += openApi.schemes[0];
   } else {
-    baseUrl += 'http'
+    baseUrl += 'http';
   }
 
   if (openApi.basePath === '/') {
-    baseUrl += '://' + openApi.host
+    baseUrl += '://' + openApi.host;
   } else {
-    baseUrl += '://' + openApi.host + openApi.basePath
+    baseUrl += '://' + openApi.host + openApi.basePath;
   }
 
-  return baseUrl
+  return baseUrl;
+};
+
+/**
+ * Gets an object describing the the paremeters (header or query) in a given OpenAPI method
+ * @param {Object} param  parameter values to use in snippet
+ * @param {Object} values Optional: query parameter values to use in the snippet if present
+ * @returns {Object}      Object describing the parameters in a given OpenAPI method
+ */
+ const getParameterValues = function (param, values) {
+  let value = 'SOME_' + (param.type || param.schema.type).toUpperCase() + '_VALUE'
+  if (values && typeof values[param.name] !== 'undefined') {
+    value = values[param.name] + ''  /* adding a empty string to convert to string */
+  } else if (typeof param.default !== 'undefined') {
+    value = param.default + ''
+  } else if (typeof param.schema !== 'undefined' && typeof param.schema.example !== 'undefined') {
+    value = param.schema.example + ''
+  } else if (typeof param.example !== 'undefined'){
+    value = param.example + ''
+  }
+  return {
+    name: param.name,
+    value: value
+  }
 }
 
 /**
@@ -140,46 +187,37 @@ const getBaseUrl = function (openApi) {
 const getQueryStrings = function (openApi, path, method, values) {
   // Set the optional parameter if it's not provided
   if (typeof values === 'undefined') {
-    values = {}
+    values = {};
   }
 
-  const queryStrings = []
+  const queryStrings = [];
 
   if (typeof openApi.paths[path][method].parameters !== 'undefined') {
     for (let i in openApi.paths[path][method].parameters) {
-      let param = openApi.paths[path][method].parameters[i]
-      if (typeof param['$ref'] === 'string' &&
-        /^#/.test(param['$ref'])) {
-        param = resolveRef(openApi, param['$ref'])
+      let param = openApi.paths[path][method].parameters[i];
+      if (typeof param['$ref'] === 'string' && /^#/.test(param['$ref'])) {
+        param = resolveRef(openApi, param['$ref']);
       }
       if (typeof param.schema !== 'undefined') {
-        if (typeof param.schema['$ref'] === 'string' &&
-          /^#/.test(param.schema['$ref'])) {
-          param.schema = resolveRef(openApi, param.schema['$ref'])
-          if (typeof param.schema.type === 'undefined') { // many schemas don't have an explicit type
+        if (
+          typeof param.schema['$ref'] === 'string' &&
+          /^#/.test(param.schema['$ref'])
+        ) {
+          param.schema = resolveRef(openApi, param.schema['$ref']);
+          if (typeof param.schema.type === 'undefined') {
+            // many schemas don't have an explicit type
             param.schema.type = 'object';
           }
         }
       }
       if (typeof param.in !== 'undefined' && param.in.toLowerCase() === 'query') {
-        let value = 'SOME_' + (param.type || param.schema.type).toUpperCase() + '_VALUE'
-        if (typeof values[param.name] !== 'undefined') {
-          value = values[param.name] + ''  /* adding a empty string to convert to string */
-        } else if (typeof param.default !== 'undefined') {
-          value = param.default + ''
-        } else if (typeof param.schema !== 'undefined' && typeof param.schema.example !== 'undefined') {
-          value = param.schema.example + ''
-        }
-        queryStrings.push({
-          name: param.name,
-          value: value
-        })
+        queryStrings.push(getParameterValues(param, values))
       }
     }
   }
 
-  return queryStrings
-}
+  return queryStrings;
+};
 
 /**
  * Return the path with the parameters example values used if specified.
@@ -190,25 +228,29 @@ const getQueryStrings = function (openApi, path, method, values) {
  * @return {string}         Full path including example values
  */
 const getFullPath = function (openApi, path, method) {
-  let fullPath = path
-  const parameters = openApi.paths[path].parameters || openApi.paths[path][method].parameters;
+  let fullPath = path;
+  const parameters =
+    openApi.paths[path].parameters || openApi.paths[path][method].parameters;
 
   if (typeof parameters !== 'undefined') {
     for (let i in parameters) {
-      let param = parameters[i]
-      if (typeof param['$ref'] === 'string' &&
-        /^#/.test(param['$ref'])) {
-        param = resolveRef(openApi, param['$ref'])
+      let param = parameters[i];
+      if (typeof param['$ref'] === 'string' && /^#/.test(param['$ref'])) {
+        param = resolveRef(openApi, param['$ref']);
       }
-      if (typeof param.in !== 'undefined' && param.in.toLowerCase() === 'path') {
-        if (typeof param.example !== 'undefined') { // only if the schema has an example value
-          fullPath = fullPath.replace("{" + param.name + "}", param.example)
+      if (
+        typeof param.in !== 'undefined' &&
+        param.in.toLowerCase() === 'path'
+      ) {
+        if (typeof param.example !== 'undefined') {
+          // only if the schema has an example value
+          fullPath = fullPath.replace('{' + param.name + '}', param.example);
         }
       }
     }
   }
-  return fullPath
-}
+  return fullPath;
+};
 
 /**
  * Get an array of objects describing the header for a path and method pair
@@ -220,39 +262,39 @@ const getFullPath = function (openApi, path, method) {
  * @return {array}          List of objects describing the header
  */
 const getHeadersArray = function (openApi, path, method) {
-  const headers = []
-  const pathObj = openApi.paths[path][method]
+  const headers = [];
+  const pathObj = openApi.paths[path][method];
 
   // 'accept' header:
   if (typeof pathObj.consumes !== 'undefined') {
     for (let i in pathObj.consumes) {
-      const type = pathObj.consumes[i]
+      const type = pathObj.consumes[i];
       headers.push({
         name: 'accept',
-        value: type
-      })
+        value: type,
+      });
     }
   }
 
   // 'content-type' header:
   if (typeof pathObj.produces !== 'undefined') {
     for (let j in pathObj.produces) {
-      const type2 = pathObj.produces[j]
+      const type2 = pathObj.produces[j];
       headers.push({
         name: 'content-type',
-        value: type2
-      })
+        value: type2,
+      });
     }
   }
 
   // v3 'content-type' header:
   if (pathObj.requestBody && pathObj.requestBody.content) {
-      for (const type3 of Object.keys(pathObj.requestBody.content)) {
-          headers.push({
-              name: 'content-type',
-              value: type3
-          });
-      }
+    for (const type3 of Object.keys(pathObj.requestBody.content)) {
+      headers.push({
+        name: 'content-type',
+        value: type3,
+      });
+    }
   }
 
   // headers defined in path object:
@@ -260,89 +302,86 @@ const getHeadersArray = function (openApi, path, method) {
     for (let k in pathObj.parameters) {
       const param = pathObj.parameters[k]
       if (typeof param.in !== 'undefined' && param.in.toLowerCase() === 'header') {
-        headers.push({
-          name: param.name,
-          value: 'SOME_' + (param.type||param.schema.type).toUpperCase() + '_VALUE'
-        })
+        headers.push(getParameterValues(param))
       }
     }
   }
 
   // security:
-  let basicAuthDef
-  let apiKeyAuthDef
-  let oauthDef
+  let basicAuthDef;
+  let apiKeyAuthDef;
+  let oauthDef;
   if (typeof pathObj.security !== 'undefined') {
     for (var l in pathObj.security) {
-      const secScheme = Object.keys(pathObj.security[l])[0]
-      const secDefinition = openApi.securityDefinitions ?
-        openApi.securityDefinitions[secScheme] :
-        openApi.components.securitySchemes[secScheme];
+      const secScheme = Object.keys(pathObj.security[l])[0];
+      const secDefinition = openApi.securityDefinitions
+        ? openApi.securityDefinitions[secScheme]
+        : openApi.components.securitySchemes[secScheme];
       const authType = secDefinition.type.toLowerCase();
       let authScheme = null;
 
-      if(authType !== 'apikey' && secDefinition.scheme != null){
+      if (authType !== 'apikey' && secDefinition.scheme != null) {
         authScheme = secDefinition.scheme.toLowerCase();
       }
 
       switch (authType) {
         case 'basic':
-          basicAuthDef = secScheme
-          break
+          basicAuthDef = secScheme;
+          break;
         case 'apikey':
           if (secDefinition.in === 'header') {
-            apiKeyAuthDef = secDefinition
+            apiKeyAuthDef = secDefinition;
           }
-          break
+          break;
         case 'oauth2':
-          oauthDef = secScheme
-          break
+          oauthDef = secScheme;
+          break;
         case 'http':
-          switch(authScheme){
+          switch (authScheme) {
             case 'bearer':
-              oauthDef = secScheme
-              break
+              oauthDef = secScheme;
+              break;
             case 'basic':
-              basicAuthDef = secScheme
-              break
+              basicAuthDef = secScheme;
+              break;
           }
-          break
+          break;
       }
     }
   } else if (typeof openApi.security !== 'undefined') {
     // Need to check OAS 3.0 spec about type http and scheme
     for (let m in openApi.security) {
-      const secScheme = Object.keys(openApi.security[m])[0]
+      const secScheme = Object.keys(openApi.security[m])[0];
       const secDefinition = openApi.components.securitySchemes[secScheme];
       const authType = secDefinition.type.toLowerCase();
       let authScheme = null;
-      
-      if(authType !== 'apikey' && authType !== 'oauth2'){
+
+      if (authType !== 'apikey' && authType !== 'oauth2') {
         authScheme = secDefinition.scheme.toLowerCase();
       }
-      
+
       switch (authType) {
         case 'http':
-          switch(authScheme){
-            case 'bearer': 
-              oauthDef = secScheme
-              break
+          switch (authScheme) {
+            case 'bearer':
+              oauthDef = secScheme;
+              break;
             case 'basic':
-              basicAuthDef = secScheme
-              break
+              basicAuthDef = secScheme;
+              break;
           }
-          break
+          break;
         case 'basic':
-          basicAuthDef = secScheme
-          break
+          basicAuthDef = secScheme;
+          break;
         case 'apikey':
           if (secDefinition.in === 'header') {
-            apiKeyAuthDef = secDefinition
+            apiKeyAuthDef = secDefinition;
           }
-          break
+          break;
         case 'oauth2':
-          oauthDef = secScheme
-          break
+          oauthDef = secScheme;
+          break;
       }
     }
   }
@@ -350,22 +389,22 @@ const getHeadersArray = function (openApi, path, method) {
   if (basicAuthDef) {
     headers.push({
       name: 'Authorization',
-      value: 'Basic ' + 'REPLACE_BASIC_AUTH'
-    })
+      value: 'Basic ' + 'REPLACE_BASIC_AUTH',
+    });
   } else if (apiKeyAuthDef) {
     headers.push({
       name: apiKeyAuthDef.name,
-      value: 'REPLACE_KEY_VALUE'
-    })
+      value: 'REPLACE_KEY_VALUE',
+    });
   } else if (oauthDef) {
     headers.push({
       name: 'Authorization',
-      value: 'Bearer ' + 'REPLACE_BEARER_TOKEN'
-    })
+      value: 'Bearer ' + 'REPLACE_BEARER_TOKEN',
+    });
   }
 
-  return headers
-}
+  return headers;
+};
 
 /**
  * Produces array of HAR files for given OpenAPI document
@@ -375,29 +414,28 @@ const getHeadersArray = function (openApi, path, method) {
  */
 const openApiToHarList = function (openApi) {
   try {
-    // determine basePath:
-    const baseUrl = getBaseUrl(openApi)
-
     // iterate openApi and create har objects:
-    const harList = []
+    const harList = [];
     for (let path in openApi.paths) {
       for (let method in openApi.paths[path]) {
-        const url = baseUrl + path
-        const har = createHar(openApi, path, method)
+        const url = getBaseUrl(openApi, path, method) + path;
+        const har = createHar(openApi, path, method);
         harList.push({
           method: method.toUpperCase(),
           url: url,
-          description: openApi.paths[path][method].description || 'No description available',
-          har: har
-        })
+          description:
+            openApi.paths[path][method].description ||
+            'No description available',
+          har: har,
+        });
       }
     }
 
-    return harList
+    return harList;
   } catch (e) {
     console.log(e);
   }
-}
+};
 
 /**
  * Returns the value referenced in the given reference string
@@ -407,22 +445,23 @@ const openApiToHarList = function (openApi) {
  * @return {any}
  */
 const resolveRef = function (openApi, ref) {
-  const parts = ref.split('/')
+  const parts = ref.split('/');
 
-  if (parts.length <= 1) return {} // = 3
+  if (parts.length <= 1) return {}; // = 3
 
   const recursive = function (obj, index) {
-    if (index + 1 < parts.length) { // index = 1
-      let newCount = index + 1
-      return recursive(obj[parts[index]], newCount)
+    if (index + 1 < parts.length) {
+      // index = 1
+      let newCount = index + 1;
+      return recursive(obj[parts[index]], newCount);
     } else {
-      return obj[parts[index]]
+      return obj[parts[index]];
     }
-  }
-  return recursive(openApi, 1)
-}
+  };
+  return recursive(openApi, 1);
+};
 
 module.exports = {
   getAll: openApiToHarList,
-  getEndpoint: createHar
-}
+  getEndpoint: createHar,
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,19 +1,2681 @@
 {
   "name": "openapi-snippet",
-  "version": "0.9.1",
-  "lockfileVersion": 1,
+  "version": "0.9.2",
+  "lockfileVersion": 2,
   "requires": true,
-  "dependencies": {
-    "JSONStream": {
+  "packages": {
+    "": {
+      "version": "0.9.2",
+      "license": "MIT",
+      "dependencies": {
+        "httpsnippet": "^1.16.7",
+        "openapi-sampler": "^1.0.0-beta.14"
+      },
+      "devDependencies": {
+        "browserify": "^16.2.3",
+        "prettier": "2.3.0",
+        "tap-spec": "^2.2.2",
+        "tape": "^4.10.1",
+        "uglifyify": "^5.0.2"
+      }
+    },
+    "node_modules/acorn": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.1.1.tgz",
+      "integrity": "sha512-add7dgA5ppRPxCFJoAGfMDi7PIBXq1RtGo7BhbLaxwrXPOmw8gq48Y9ozT01hUKy9byMjlR20EJhu5zlkErEkg==",
+      "dev": true,
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-node": {
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/acorn-node/-/acorn-node-1.8.2.tgz",
+      "integrity": "sha512-8mt+fslDufLYntIoPAaIMUe/lrbrehIiwmR3t2k9LljIzoigEPF27eLk2hy8zSGzmR/ogr7zbRKINMo1u0yh5A==",
+      "dev": true,
+      "dependencies": {
+        "acorn": "^7.0.0",
+        "acorn-walk": "^7.0.0",
+        "xtend": "^4.0.2"
+      }
+    },
+    "node_modules/acorn-walk": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-7.1.1.tgz",
+      "integrity": "sha512-wdlPY2tm/9XBr7QkKlq0WQVgiuGTX6YWPyRyBviSoScBuLfTVQhvwg6wJ369GJ/1nPfTLMfnrFIfjqVg6d+jQQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "6.12.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.0.tgz",
+      "integrity": "sha512-D6gFiFA0RRLyUbvijN74DWAjXSFxWKaWP7mldxkVhyhAV3+SWA9HEJPHQ2c9soIeTFJqcSdFDGFgdqs1iUU2Hw==",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+      "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/array-find-index": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
+      "integrity": "sha1-3wEKoSh+Fku9pvlyOwqWoexBh6E=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/asn1.js": {
+      "version": "4.10.1",
+      "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.10.1.tgz",
+      "integrity": "sha512-p32cOF5q0Zqs9uBiONKYLm6BClCoBCM5O9JfeUSlnQLBTxYdTK+pW+nXflm8UkKd2UYlEbYz5qEi0JuZR9ckSw==",
+      "dev": true,
+      "dependencies": {
+        "bn.js": "^4.0.0",
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0"
+      }
+    },
+    "node_modules/assert": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/assert/-/assert-1.5.0.tgz",
+      "integrity": "sha512-EDsgawzwoun2CZkCgtxJbv392v4nbk9XDD06zI+kQYoBM/3RBWLlEyJARDOmhAAosBjWACEkKL6S+lIZtcAubA==",
+      "dev": true,
+      "dependencies": {
+        "object-assign": "^4.1.1",
+        "util": "0.10.3"
+      }
+    },
+    "node_modules/assert/node_modules/inherits": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+      "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE=",
+      "dev": true
+    },
+    "node_modules/assert/node_modules/util": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
+      "integrity": "sha1-evsa/lCAUkZInj23/g7TeTNqwPk=",
+      "dev": true,
+      "dependencies": {
+        "inherits": "2.0.1"
+      }
+    },
+    "node_modules/async": {
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
+      "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
+      "dependencies": {
+        "lodash": "^4.17.14"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+      "dev": true
+    },
+    "node_modules/base64-js": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.1.tgz",
+      "integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g==",
+      "dev": true
+    },
+    "node_modules/bn.js": {
+      "version": "4.11.8",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
+      "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA==",
+      "dev": true
+    },
+    "node_modules/brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/brorand": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
+      "integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8=",
+      "dev": true
+    },
+    "node_modules/browser-pack": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/browser-pack/-/browser-pack-6.1.0.tgz",
+      "integrity": "sha512-erYug8XoqzU3IfcU8fUgyHqyOXqIE4tUTTQ+7mqUjQlvnXkOO6OlT9c/ZoJVHYoAaqGxr09CN53G7XIsO4KtWA==",
+      "dev": true,
+      "dependencies": {
+        "combine-source-map": "~0.8.0",
+        "defined": "^1.0.0",
+        "JSONStream": "^1.0.3",
+        "safe-buffer": "^5.1.1",
+        "through2": "^2.0.0",
+        "umd": "^3.0.0"
+      },
+      "bin": {
+        "browser-pack": "bin/cmd.js"
+      }
+    },
+    "node_modules/browser-resolve": {
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/browser-resolve/-/browser-resolve-1.11.3.tgz",
+      "integrity": "sha512-exDi1BYWB/6raKHmDTCicQfTkqwN5fioMFV4j8BsfMU4R2DK/QfZfK7kOVkmWCNANf0snkBzqGqAJBao9gZMdQ==",
+      "dev": true,
+      "dependencies": {
+        "resolve": "1.1.7"
+      }
+    },
+    "node_modules/browser-resolve/node_modules/resolve": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
+      "integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=",
+      "dev": true
+    },
+    "node_modules/browserify": {
+      "version": "16.5.1",
+      "resolved": "https://registry.npmjs.org/browserify/-/browserify-16.5.1.tgz",
+      "integrity": "sha512-EQX0h59Pp+0GtSRb5rL6OTfrttlzv+uyaUVlK6GX3w11SQ0jKPKyjC/54RhPR2ib2KmfcELM06e8FxcI5XNU2A==",
+      "dev": true,
+      "dependencies": {
+        "assert": "^1.4.0",
+        "browser-pack": "^6.0.1",
+        "browser-resolve": "^1.11.0",
+        "browserify-zlib": "~0.2.0",
+        "buffer": "~5.2.1",
+        "cached-path-relative": "^1.0.0",
+        "concat-stream": "^1.6.0",
+        "console-browserify": "^1.1.0",
+        "constants-browserify": "~1.0.0",
+        "crypto-browserify": "^3.0.0",
+        "defined": "^1.0.0",
+        "deps-sort": "^2.0.0",
+        "domain-browser": "^1.2.0",
+        "duplexer2": "~0.1.2",
+        "events": "^2.0.0",
+        "glob": "^7.1.0",
+        "has": "^1.0.0",
+        "htmlescape": "^1.1.0",
+        "https-browserify": "^1.0.0",
+        "inherits": "~2.0.1",
+        "insert-module-globals": "^7.0.0",
+        "JSONStream": "^1.0.3",
+        "labeled-stream-splicer": "^2.0.0",
+        "mkdirp-classic": "^0.5.2",
+        "module-deps": "^6.0.0",
+        "os-browserify": "~0.3.0",
+        "parents": "^1.0.1",
+        "path-browserify": "~0.0.0",
+        "process": "~0.11.0",
+        "punycode": "^1.3.2",
+        "querystring-es3": "~0.2.0",
+        "read-only-stream": "^2.0.0",
+        "readable-stream": "^2.0.2",
+        "resolve": "^1.1.4",
+        "shasum": "^1.0.0",
+        "shell-quote": "^1.6.1",
+        "stream-browserify": "^2.0.0",
+        "stream-http": "^3.0.0",
+        "string_decoder": "^1.1.1",
+        "subarg": "^1.0.0",
+        "syntax-error": "^1.1.1",
+        "through2": "^2.0.0",
+        "timers-browserify": "^1.0.1",
+        "tty-browserify": "0.0.1",
+        "url": "~0.11.0",
+        "util": "~0.10.1",
+        "vm-browserify": "^1.0.0",
+        "xtend": "^4.0.0"
+      },
+      "bin": {
+        "browserify": "bin/cmd.js"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/browserify-aes": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
+      "integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
+      "dev": true,
+      "dependencies": {
+        "buffer-xor": "^1.0.3",
+        "cipher-base": "^1.0.0",
+        "create-hash": "^1.1.0",
+        "evp_bytestokey": "^1.0.3",
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/browserify-cipher": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/browserify-cipher/-/browserify-cipher-1.0.1.tgz",
+      "integrity": "sha512-sPhkz0ARKbf4rRQt2hTpAHqn47X3llLkUGn+xEJzLjwY8LRs2p0v7ljvI5EyoRO/mexrNunNECisZs+gw2zz1w==",
+      "dev": true,
+      "dependencies": {
+        "browserify-aes": "^1.0.4",
+        "browserify-des": "^1.0.0",
+        "evp_bytestokey": "^1.0.0"
+      }
+    },
+    "node_modules/browserify-des": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/browserify-des/-/browserify-des-1.0.2.tgz",
+      "integrity": "sha512-BioO1xf3hFwz4kc6iBhI3ieDFompMhrMlnDFC4/0/vd5MokpuAc3R+LYbwTA9A5Yc9pq9UYPqffKpW2ObuwX5A==",
+      "dev": true,
+      "dependencies": {
+        "cipher-base": "^1.0.1",
+        "des.js": "^1.0.0",
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.1.2"
+      }
+    },
+    "node_modules/browserify-rsa": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
+      "integrity": "sha1-IeCr+vbyApzy+vsTNWenAdQTVSQ=",
+      "dev": true,
+      "dependencies": {
+        "bn.js": "^4.1.0",
+        "randombytes": "^2.0.1"
+      }
+    },
+    "node_modules/browserify-sign": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.0.4.tgz",
+      "integrity": "sha1-qk62jl17ZYuqa/alfmMMvXqT0pg=",
+      "dev": true,
+      "dependencies": {
+        "bn.js": "^4.1.1",
+        "browserify-rsa": "^4.0.0",
+        "create-hash": "^1.1.0",
+        "create-hmac": "^1.1.2",
+        "elliptic": "^6.0.0",
+        "inherits": "^2.0.1",
+        "parse-asn1": "^5.0.0"
+      }
+    },
+    "node_modules/browserify-zlib": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.2.0.tgz",
+      "integrity": "sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA==",
+      "dev": true,
+      "dependencies": {
+        "pako": "~1.0.5"
+      }
+    },
+    "node_modules/browserify/node_modules/punycode": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+      "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
+      "dev": true
+    },
+    "node_modules/buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.2.1.tgz",
+      "integrity": "sha512-c+Ko0loDaFfuPWiL02ls9Xd3GO3cPVmUobQ6t3rXNUk304u6hGq+8N/kFi+QEIKhzK3uwolVhLzszmfLmMLnqg==",
+      "dev": true,
+      "dependencies": {
+        "base64-js": "^1.0.2",
+        "ieee754": "^1.1.4"
+      }
+    },
+    "node_modules/buffer-from": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
+      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
+      "dev": true
+    },
+    "node_modules/buffer-xor": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz",
+      "integrity": "sha1-JuYe0UIvtw3ULm42cp7VHYVf6Nk=",
+      "dev": true
+    },
+    "node_modules/builtin-status-codes": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz",
+      "integrity": "sha1-hZgoeOIbmOHGZCXgPQF0eI9Wnug=",
+      "dev": true
+    },
+    "node_modules/cached-path-relative": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/cached-path-relative/-/cached-path-relative-1.0.2.tgz",
+      "integrity": "sha512-5r2GqsoEb4qMTTN9J+WzXfjov+hjxT+j3u5K+kIVNIwAd99DLCJE9pBIMP1qVeybV6JiijL385Oz0DcYxfbOIg==",
+      "dev": true
+    },
+    "node_modules/camelcase": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
+      "integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/camelcase-keys": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
+      "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
+      "dev": true,
+      "dependencies": {
+        "camelcase": "^2.0.0",
+        "map-obj": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+      "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+      "dependencies": {
+        "ansi-styles": "^2.2.1",
+        "escape-string-regexp": "^1.0.2",
+        "has-ansi": "^2.0.0",
+        "strip-ansi": "^3.0.0",
+        "supports-color": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/cipher-base": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
+      "integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
+      "dev": true,
+      "dependencies": {
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/combine-source-map": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/combine-source-map/-/combine-source-map-0.8.0.tgz",
+      "integrity": "sha1-pY0N8ELBhvz4IqjoAV9UUNLXmos=",
+      "dev": true,
+      "dependencies": {
+        "convert-source-map": "~1.1.0",
+        "inline-source-map": "~0.6.0",
+        "lodash.memoize": "~3.0.3",
+        "source-map": "~0.5.3"
+      }
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
+    },
+    "node_modules/concat-stream": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
+      "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
+      "dev": true,
+      "engines": [
+        "node >= 0.8"
+      ],
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^2.2.2",
+        "typedarray": "^0.0.6"
+      }
+    },
+    "node_modules/console-browserify": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.2.0.tgz",
+      "integrity": "sha512-ZMkYO/LkF17QvCPqM0gxw8yUzigAOZOSWSHg91FH6orS7vcEj5dVZTidN2fQ14yBSdg97RqhSNwLUXInd52OTA==",
+      "dev": true
+    },
+    "node_modules/constants-browserify": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/constants-browserify/-/constants-browserify-1.0.0.tgz",
+      "integrity": "sha1-wguW2MYXdIqvHBYCF2DNJ/y4y3U=",
+      "dev": true
+    },
+    "node_modules/convert-source-map": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.1.3.tgz",
+      "integrity": "sha1-SCnId+n+SbMWHzvzZziI4gRpmGA=",
+      "dev": true
+    },
+    "node_modules/core-util-is": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+      "dev": true
+    },
+    "node_modules/create-ecdh": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.3.tgz",
+      "integrity": "sha512-GbEHQPMOswGpKXM9kCWVrremUcBmjteUaQ01T9rkKCPDXfUHX0IoP9LpHYo2NPFampa4e+/pFDc3jQdxrxQLaw==",
+      "dev": true,
+      "dependencies": {
+        "bn.js": "^4.1.0",
+        "elliptic": "^6.0.0"
+      }
+    },
+    "node_modules/create-hash": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
+      "integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
+      "dev": true,
+      "dependencies": {
+        "cipher-base": "^1.0.1",
+        "inherits": "^2.0.1",
+        "md5.js": "^1.3.4",
+        "ripemd160": "^2.0.1",
+        "sha.js": "^2.4.0"
+      }
+    },
+    "node_modules/create-hmac": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
+      "integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
+      "dev": true,
+      "dependencies": {
+        "cipher-base": "^1.0.3",
+        "create-hash": "^1.1.0",
+        "inherits": "^2.0.1",
+        "ripemd160": "^2.0.0",
+        "safe-buffer": "^5.0.1",
+        "sha.js": "^2.4.8"
+      }
+    },
+    "node_modules/crypto-browserify": {
+      "version": "3.12.0",
+      "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.12.0.tgz",
+      "integrity": "sha512-fz4spIh+znjO2VjL+IdhEpRJ3YN6sMzITSBijk6FK2UvTqruSQW+/cCZTSNsMiZNvUeq0CqurF+dAbyiGOY6Wg==",
+      "dev": true,
+      "dependencies": {
+        "browserify-cipher": "^1.0.0",
+        "browserify-sign": "^4.0.0",
+        "create-ecdh": "^4.0.0",
+        "create-hash": "^1.1.0",
+        "create-hmac": "^1.1.0",
+        "diffie-hellman": "^5.0.0",
+        "inherits": "^2.0.1",
+        "pbkdf2": "^3.0.3",
+        "public-encrypt": "^4.0.0",
+        "randombytes": "^2.0.0",
+        "randomfill": "^1.0.3"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/currently-unhandled": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
+      "integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
+      "dev": true,
+      "dependencies": {
+        "array-find-index": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/dash-ast": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/dash-ast/-/dash-ast-1.0.0.tgz",
+      "integrity": "sha512-Vy4dx7gquTeMcQR/hDkYLGUnwVil6vk4FOOct+djUnHOUWt+zJPJAaRIXaAFkPXtJjvlY7o3rfRu0/3hpnwoUA==",
+      "dev": true
+    },
+    "node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/decamelize": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/deep-equal": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.1.1.tgz",
+      "integrity": "sha512-yd9c5AdiqVcR+JjcwUQb9DkhJc8ngNr0MahEBGvDiJw8puWab2yZlh+nkasOnZP+EGTAP6rRp2JzJhJZzvNF8g==",
+      "dev": true,
+      "dependencies": {
+        "is-arguments": "^1.0.4",
+        "is-date-object": "^1.0.1",
+        "is-regex": "^1.0.4",
+        "object-is": "^1.0.1",
+        "object-keys": "^1.1.1",
+        "regexp.prototype.flags": "^1.2.0"
+      }
+    },
+    "node_modules/define-properties": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
+      "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
+      "dev": true,
+      "dependencies": {
+        "object-keys": "^1.0.12"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/defined": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
+      "integrity": "sha1-yY2bzvdWdBiOEQlpFRGZ45sfppM=",
+      "dev": true
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/deps-sort": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/deps-sort/-/deps-sort-2.0.1.tgz",
+      "integrity": "sha512-1orqXQr5po+3KI6kQb9A4jnXT1PBwggGl2d7Sq2xsnOeI9GPcE/tGcF9UiSZtZBM7MukY4cAh7MemS6tZYipfw==",
+      "dev": true,
+      "dependencies": {
+        "JSONStream": "^1.0.3",
+        "shasum-object": "^1.0.0",
+        "subarg": "^1.0.0",
+        "through2": "^2.0.0"
+      },
+      "bin": {
+        "deps-sort": "bin/cmd.js"
+      }
+    },
+    "node_modules/des.js": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/des.js/-/des.js-1.0.1.tgz",
+      "integrity": "sha512-Q0I4pfFrv2VPd34/vfLrFOoRmlYj3OV50i7fskps1jZWK1kApMWWT9G6RRUeYedLcBDIhnSDaUvJMb3AhUlaEA==",
+      "dev": true,
+      "dependencies": {
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0"
+      }
+    },
+    "node_modules/detective": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/detective/-/detective-5.2.0.tgz",
+      "integrity": "sha512-6SsIx+nUUbuK0EthKjv0zrdnajCCXVYGmbYYiYjFVpzcjwEs/JMDZ8tPRG29J/HhN56t3GJp2cGSWDRjjot8Pg==",
+      "dev": true,
+      "dependencies": {
+        "acorn-node": "^1.6.1",
+        "defined": "^1.0.0",
+        "minimist": "^1.1.1"
+      },
+      "bin": {
+        "detective": "bin/detective.js"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/diffie-hellman": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
+      "integrity": "sha512-kqag/Nl+f3GwyK25fhUMYj81BUOrZ9IuJsjIcDE5icNM9FJHAVm3VcUDxdLPoQtTuUylWm6ZIknYJwwaPxsUzg==",
+      "dev": true,
+      "dependencies": {
+        "bn.js": "^4.1.0",
+        "miller-rabin": "^4.0.0",
+        "randombytes": "^2.0.0"
+      }
+    },
+    "node_modules/domain-browser": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.2.0.tgz",
+      "integrity": "sha512-jnjyiM6eRyZl2H+W8Q/zLMA481hzi0eszAaBUzIVnmYVDBbnLxVNnfu1HgEBvCbL+71FrxMl3E6lpKH7Ge3OXA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.4",
+        "npm": ">=1.2"
+      }
+    },
+    "node_modules/dotignore": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/dotignore/-/dotignore-0.1.2.tgz",
+      "integrity": "sha512-UGGGWfSauusaVJC+8fgV+NVvBXkCTmVv7sk6nojDZZvuOUNGUy0Zk4UpHQD6EDjS0jpBwcACvH4eofvyzBcRDw==",
+      "dev": true,
+      "dependencies": {
+        "minimatch": "^3.0.4"
+      },
+      "bin": {
+        "ignored": "bin/ignored"
+      }
+    },
+    "node_modules/duplexer": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
+      "integrity": "sha1-rOb/gIwc5mtX0ev5eXessCM0z8E="
+    },
+    "node_modules/duplexer2": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
+      "integrity": "sha1-ixLauHjA1p4+eJEFFmKjL8a93ME=",
+      "dev": true,
+      "dependencies": {
+        "readable-stream": "^2.0.2"
+      }
+    },
+    "node_modules/elliptic": {
+      "version": "6.5.4",
+      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.4.tgz",
+      "integrity": "sha512-iLhC6ULemrljPZb+QutR5TQGB+pdW6KGD5RSegS+8sorOZT+rdQFbsQFJgvN3eRqNALqJer4oQ16YvJHlU8hzQ==",
+      "dev": true,
+      "dependencies": {
+        "bn.js": "^4.11.9",
+        "brorand": "^1.1.0",
+        "hash.js": "^1.0.0",
+        "hmac-drbg": "^1.0.1",
+        "inherits": "^2.0.4",
+        "minimalistic-assert": "^1.0.1",
+        "minimalistic-crypto-utils": "^1.0.1"
+      }
+    },
+    "node_modules/elliptic/node_modules/bn.js": {
+      "version": "4.12.0",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+      "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
+      "dev": true
+    },
+    "node_modules/error-ex": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
+      "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
+      "dev": true,
+      "dependencies": {
+        "is-arrayish": "^0.2.1"
+      }
+    },
+    "node_modules/es-abstract": {
+      "version": "1.17.5",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.5.tgz",
+      "integrity": "sha512-BR9auzDbySxOcfog0tLECW8l28eRGpDpU3Dm3Hp4q/N+VtLTmyj4EUN088XZWQDW/hzj6sYRDXeOFsaAODKvpg==",
+      "dev": true,
+      "dependencies": {
+        "es-to-primitive": "^1.2.1",
+        "function-bind": "^1.1.1",
+        "has": "^1.0.3",
+        "has-symbols": "^1.0.1",
+        "is-callable": "^1.1.5",
+        "is-regex": "^1.0.5",
+        "object-inspect": "^1.7.0",
+        "object-keys": "^1.1.1",
+        "object.assign": "^4.1.0",
+        "string.prototype.trimleft": "^2.1.1",
+        "string.prototype.trimright": "^2.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-to-primitive": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
+      "integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
+      "dev": true,
+      "dependencies": {
+        "is-callable": "^1.1.4",
+        "is-date-object": "^1.0.1",
+        "is-symbol": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/event-stream": {
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-3.3.4.tgz",
+      "integrity": "sha1-SrTJoPWlTbkzi0w02Gv86PSzVXE=",
+      "dependencies": {
+        "duplexer": "~0.1.1",
+        "from": "~0",
+        "map-stream": "~0.1.0",
+        "pause-stream": "0.0.11",
+        "split": "0.3",
+        "stream-combiner": "~0.0.4",
+        "through": "~2.3.1"
+      }
+    },
+    "node_modules/events": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/events/-/events-2.1.0.tgz",
+      "integrity": "sha512-3Zmiobend8P9DjmKAty0Era4jV8oJ0yGYe2nJJAxgymF9+N8F2m0hhZiMoWtcfepExzNKZumFU3ksdQbInGWCg==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.4.x"
+      }
+    },
+    "node_modules/evp_bytestokey": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz",
+      "integrity": "sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==",
+      "dev": true,
+      "dependencies": {
+        "md5.js": "^1.3.4",
+        "safe-buffer": "^5.1.1"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.1.tgz",
+      "integrity": "sha512-8UEa58QDLauDNfpbrX55Q9jrGHThw2ZMdOky5Gl1CDtVeJDPVrG4Jxx1N8jw2gkWaff5UUuX1KJd+9zGe2B+ZA=="
+    },
+    "node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
+    },
+    "node_modules/fast-safe-stringify": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.0.7.tgz",
+      "integrity": "sha512-Utm6CdzT+6xsDk2m8S6uL8VHxNwI6Jub+e9NYTcAms28T84pTa25GJQV9j0CY0N1rM8hK4x6grpF2BQf+2qwVA==",
+      "dev": true
+    },
+    "node_modules/find-up": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
+      "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
+      "dev": true,
+      "dependencies": {
+        "path-exists": "^2.0.0",
+        "pinkie-promise": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/for-each": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
+      "integrity": "sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==",
+      "dev": true,
+      "dependencies": {
+        "is-callable": "^1.1.3"
+      }
+    },
+    "node_modules/foreach": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
+      "integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k="
+    },
+    "node_modules/form-data": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-1.0.1.tgz",
+      "integrity": "sha1-rjFduaSQf6BlUCMEpm13M0de43w=",
+      "dependencies": {
+        "async": "^2.0.1",
+        "combined-stream": "^1.0.5",
+        "mime-types": "^2.1.11"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/from": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/from/-/from-0.1.7.tgz",
+      "integrity": "sha1-g8YK/Fi5xWmXAH7Rp2izqzA6RP4="
+    },
+    "node_modules/fs-readfile-promise": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/fs-readfile-promise/-/fs-readfile-promise-2.0.1.tgz",
+      "integrity": "sha1-gAI4I5gfn//+AWCei+Zo9prknnA=",
+      "dependencies": {
+        "graceful-fs": "^4.1.2"
+      }
+    },
+    "node_modules/fs-writefile-promise": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/fs-writefile-promise/-/fs-writefile-promise-1.0.3.tgz",
+      "integrity": "sha1-4C+bWP/CVe2CKtx6ARFPRF1I0GM=",
+      "dependencies": {
+        "mkdirp-promise": "^1.0.0",
+        "pinkie-promise": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/fs-writefile-promise/node_modules/pinkie-promise": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-1.0.0.tgz",
+      "integrity": "sha1-0dpn9UglY7t89X8oauKCLs+/NnA=",
+      "dependencies": {
+        "pinkie": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+      "dev": true
+    },
+    "node_modules/get-assigned-identifiers": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/get-assigned-identifiers/-/get-assigned-identifiers-1.2.0.tgz",
+      "integrity": "sha512-mBBwmeGTrxEMO4pMaaf/uUEFHnYtwr8FTe8Y/mer4rcV/bye0qGm6pw1bGZFGStxC5O76c5ZAVBGnqHmOaJpdQ==",
+      "dev": true
+    },
+    "node_modules/get-own-enumerable-property-symbols": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/get-own-enumerable-property-symbols/-/get-own-enumerable-property-symbols-3.0.2.tgz",
+      "integrity": "sha512-I0UBV/XOz1XkIJHEUDMZAbzCThU/H8DxmSfmdGcKPnVhu2VfFqr34jr9777IyaTYvxjedWhqVIilEDsCdP5G6g=="
+    },
+    "node_modules/get-stdin": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
+      "integrity": "sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/glob": {
+      "version": "7.1.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+      "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+      "dev": true,
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.3.tgz",
+      "integrity": "sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ=="
+    },
+    "node_modules/har-schema": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
+      "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/har-validator": {
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.3.tgz",
+      "integrity": "sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==",
+      "dependencies": {
+        "ajv": "^6.5.5",
+        "har-schema": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/has": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+      "dev": true,
+      "dependencies": {
+        "function-bind": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/has-ansi": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+      "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+      "dependencies": {
+        "ansi-regex": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
+      "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/hash-base": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.0.4.tgz",
+      "integrity": "sha1-X8hoaEfs1zSZQDMZprCj8/auSRg=",
+      "dev": true,
+      "dependencies": {
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/hash.js": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.7.tgz",
+      "integrity": "sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==",
+      "dev": true,
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "minimalistic-assert": "^1.0.1"
+      }
+    },
+    "node_modules/hmac-drbg": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
+      "integrity": "sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=",
+      "dev": true,
+      "dependencies": {
+        "hash.js": "^1.0.3",
+        "minimalistic-assert": "^1.0.0",
+        "minimalistic-crypto-utils": "^1.0.1"
+      }
+    },
+    "node_modules/hosted-git-info": {
+      "version": "2.8.9",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
+      "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
+      "dev": true
+    },
+    "node_modules/htmlescape": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/htmlescape/-/htmlescape-1.1.1.tgz",
+      "integrity": "sha1-OgPtwiFLyjtmQko+eVk0lQnLA1E=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/https-browserify": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-1.0.0.tgz",
+      "integrity": "sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM=",
+      "dev": true
+    },
+    "node_modules/httpsnippet": {
+      "version": "1.19.1",
+      "resolved": "https://registry.npmjs.org/httpsnippet/-/httpsnippet-1.19.1.tgz",
+      "integrity": "sha512-QfzcIPziGhUZPFIpKKWgwcpEm8w1jYfm7xc7IM4gpvp+pzk8aCtyS2/lRUoQ+T28m/0i/2zstquht7Km8NVQcA==",
+      "dependencies": {
+        "chalk": "^1.1.1",
+        "commander": "^2.9.0",
+        "debug": "^2.2.0",
+        "event-stream": "3.3.4",
+        "form-data": "^1.0.0-rc3",
+        "fs-readfile-promise": "^2.0.1",
+        "fs-writefile-promise": "^1.0.3",
+        "har-validator": "^5.0.0",
+        "pinkie-promise": "^2.0.0",
+        "stringify-object": "^3.3.0"
+      },
+      "bin": {
+        "httpsnippet": "bin/httpsnippet"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/ieee754": {
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
+      "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg==",
+      "dev": true
+    },
+    "node_modules/indent-string": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
+      "integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
+      "dev": true,
+      "dependencies": {
+        "repeating": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dev": true,
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true
+    },
+    "node_modules/inline-source-map": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/inline-source-map/-/inline-source-map-0.6.2.tgz",
+      "integrity": "sha1-+Tk0ccGKedFyT4Y/o4tYY3Ct4qU=",
+      "dev": true,
+      "dependencies": {
+        "source-map": "~0.5.3"
+      }
+    },
+    "node_modules/insert-module-globals": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/insert-module-globals/-/insert-module-globals-7.2.0.tgz",
+      "integrity": "sha512-VE6NlW+WGn2/AeOMd496AHFYmE7eLKkUY6Ty31k4og5vmA3Fjuwe9v6ifH6Xx/Hz27QvdoMoviw1/pqWRB09Sw==",
+      "dev": true,
+      "dependencies": {
+        "acorn-node": "^1.5.2",
+        "combine-source-map": "^0.8.0",
+        "concat-stream": "^1.6.1",
+        "is-buffer": "^1.1.0",
+        "JSONStream": "^1.0.3",
+        "path-is-absolute": "^1.0.1",
+        "process": "~0.11.0",
+        "through2": "^2.0.0",
+        "undeclared-identifiers": "^1.1.2",
+        "xtend": "^4.0.0"
+      },
+      "bin": {
+        "insert-module-globals": "bin/cmd.js"
+      }
+    },
+    "node_modules/is-arguments": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.0.4.tgz",
+      "integrity": "sha512-xPh0Rmt8NE65sNzvyUmWgI1tz3mKq74lGA0mL8LYZcoIzKOzDh6HmrYm3d18k60nHerC8A9Km8kYu87zfSFnLA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/is-arrayish": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
+      "dev": true
+    },
+    "node_modules/is-buffer": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
+      "dev": true
+    },
+    "node_modules/is-callable": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.5.tgz",
+      "integrity": "sha512-ESKv5sMCJB2jnHTWZ3O5itG+O128Hsus4K4Qh1h2/cgn2vbgnLSVqfV46AeJA9D5EeeLa9w81KUXMtn34zhX+Q==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/is-date-object": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.2.tgz",
+      "integrity": "sha512-USlDT524woQ08aoZFzh3/Z6ch9Y/EWXEHQ/AaRN0SkKq4t2Jw2R2339tSXmwuVoY7LLlBCbOIlx2myP/L5zk0g==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/is-finite": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.1.0.tgz",
+      "integrity": "sha512-cdyMtqX/BOqqNBBiKlIVkytNHm49MtMlYyn1zxzvJKWmFMlGzm+ry5BBfYyeY9YmNKbRSo/o7OX9w9ale0wg3w==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-obj": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
+      "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-regex": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.5.tgz",
+      "integrity": "sha512-vlKW17SNq44owv5AQR3Cq0bQPEb8+kF3UKZ2fiZNOWtztYE5i0CzCZxFDwO58qAOWtxdBRVO/V5Qin1wjCqFYQ==",
+      "dev": true,
+      "dependencies": {
+        "has": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/is-regexp": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-regexp/-/is-regexp-1.0.0.tgz",
+      "integrity": "sha1-/S2INUXEa6xaYz57mgnof6LLUGk=",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-symbol": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.3.tgz",
+      "integrity": "sha512-OwijhaRSgqvhm/0ZdAcXNZt9lYdKFpcRDT5ULUuYXPoT794UNOdU+gpT6Rzo7b4V2HUl/op6GqY894AZwv9faQ==",
+      "dev": true,
+      "dependencies": {
+        "has-symbols": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/is-utf8": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
+      "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
+      "dev": true
+    },
+    "node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+      "dev": true
+    },
+    "node_modules/json-pointer": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/json-pointer/-/json-pointer-0.6.1.tgz",
+      "integrity": "sha512-3OvjqKdCBvH41DLpV4iSt6v2XhZXV1bPB4OROuknvUXI7ZQNofieCPkmE26stEJ9zdQuvIxDHCuYhfgxFAAs+Q==",
+      "dependencies": {
+        "foreach": "^2.0.4"
+      }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
+    },
+    "node_modules/json-stable-stringify": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-0.0.1.tgz",
+      "integrity": "sha1-YRwj6BTbN1Un34URk9tZ3Sryf0U=",
+      "dev": true,
+      "dependencies": {
+        "jsonify": "~0.0.0"
+      }
+    },
+    "node_modules/jsonify": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
+      "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
+      "dev": true
+    },
+    "node_modules/jsonparse": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
+      "integrity": "sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA=",
+      "dev": true,
+      "engines": [
+        "node >= 0.2.0"
+      ]
+    },
+    "node_modules/JSONStream": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.5.tgz",
       "integrity": "sha512-E+iruNOY8VV9s4JEbe1aNEm6MiszPRr/UfcHMz0TQh1BXSxHK+ASV1R6W4HpjBhSeS+54PIsAMCBmwD06LLsqQ==",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "jsonparse": "^1.2.0",
         "through": ">=2.2.7 <3"
+      },
+      "bin": {
+        "JSONStream": "bin.js"
+      },
+      "engines": {
+        "node": "*"
       }
     },
+    "node_modules/labeled-stream-splicer": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/labeled-stream-splicer/-/labeled-stream-splicer-2.0.2.tgz",
+      "integrity": "sha512-Ca4LSXFFZUjPScRaqOcFxneA0VpKZr4MMYCljyQr4LIewTLb3Y0IUTIsnBBsVubIeEfxeSZpSjSsRM8APEQaAw==",
+      "dev": true,
+      "dependencies": {
+        "inherits": "^2.0.1",
+        "stream-splicer": "^2.0.0"
+      }
+    },
+    "node_modules/load-json-file": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+      "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
+      "dev": true,
+      "dependencies": {
+        "graceful-fs": "^4.1.2",
+        "parse-json": "^2.2.0",
+        "pify": "^2.0.0",
+        "pinkie-promise": "^2.0.0",
+        "strip-bom": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+    },
+    "node_modules/lodash.memoize": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-3.0.4.tgz",
+      "integrity": "sha1-LcvSwofLwKVcxCMovQxzYVDVPj8=",
+      "dev": true
+    },
+    "node_modules/loud-rejection": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz",
+      "integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
+      "dev": true,
+      "dependencies": {
+        "currently-unhandled": "^0.4.1",
+        "signal-exit": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/map-obj": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
+      "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/map-stream": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/map-stream/-/map-stream-0.1.0.tgz",
+      "integrity": "sha1-5WqpTEyAVaFkBKBnS3jyFffI4ZQ="
+    },
+    "node_modules/md5.js": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.5.tgz",
+      "integrity": "sha512-xitP+WxNPcTTOgnTJcrhM0xvdPepipPSf3I8EIpGKeFLjt3PlJLIDG3u8EX53ZIubkb+5U2+3rELYpEhHhzdkg==",
+      "dev": true,
+      "dependencies": {
+        "hash-base": "^3.0.0",
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.1.2"
+      }
+    },
+    "node_modules/meow": {
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
+      "integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
+      "dev": true,
+      "dependencies": {
+        "camelcase-keys": "^2.0.0",
+        "decamelize": "^1.1.2",
+        "loud-rejection": "^1.0.0",
+        "map-obj": "^1.0.1",
+        "minimist": "^1.1.3",
+        "normalize-package-data": "^2.3.4",
+        "object-assign": "^4.0.1",
+        "read-pkg-up": "^1.0.1",
+        "redent": "^1.0.0",
+        "trim-newlines": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/miller-rabin": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-4.0.1.tgz",
+      "integrity": "sha512-115fLhvZVqWwHPbClyntxEVfVDfl9DLLTuJvq3g2O/Oxi8AiNouAHvDSzHS0viUJc+V5vm3eq91Xwqn9dp4jRA==",
+      "dev": true,
+      "dependencies": {
+        "bn.js": "^4.0.0",
+        "brorand": "^1.0.1"
+      },
+      "bin": {
+        "miller-rabin": "bin/miller-rabin"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.43.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.43.0.tgz",
+      "integrity": "sha512-+5dsGEEovYbT8UY9yD7eE4XTc4UwJ1jBYlgaQQF38ENsKR3wj/8q8RFZrF9WIZpB2V1ArTVFUva8sAul1NzRzQ==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.26",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.26.tgz",
+      "integrity": "sha512-01paPWYgLrkqAyrlDorC1uDwl2p3qZT7yl806vW7DvDoxwXi46jsjFbg+WdwotBIk6/MbEhO/dh5aZ5sNj/dWQ==",
+      "dependencies": {
+        "mime-db": "1.43.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/minimalistic-assert": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
+      "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==",
+      "dev": true
+    },
+    "node_modules/minimalistic-crypto-utils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
+      "integrity": "sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo=",
+      "dev": true
+    },
+    "node_modules/minimatch": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+      "dev": true
+    },
+    "node_modules/mkdirp-classic": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.2.tgz",
+      "integrity": "sha512-ejdnDQcR75gwknmMw/tx02AuRs8jCtqFoFqDZMjiNxsu85sRIJVXDKHuLYvUUPRBUtV2FpSZa9bL1BUa3BdR2g==",
+      "dev": true
+    },
+    "node_modules/mkdirp-promise": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/mkdirp-promise/-/mkdirp-promise-1.1.0.tgz",
+      "integrity": "sha1-LISJPtZ24NmPsY+5piEv0bK5qBk=",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/module-deps": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/module-deps/-/module-deps-6.2.2.tgz",
+      "integrity": "sha512-a9y6yDv5u5I4A+IPHTnqFxcaKr4p50/zxTjcQJaX2ws9tN/W6J6YXnEKhqRyPhl494dkcxx951onSKVezmI+3w==",
+      "dev": true,
+      "dependencies": {
+        "browser-resolve": "^1.7.0",
+        "cached-path-relative": "^1.0.2",
+        "concat-stream": "~1.6.0",
+        "defined": "^1.0.0",
+        "detective": "^5.2.0",
+        "duplexer2": "^0.1.2",
+        "inherits": "^2.0.1",
+        "JSONStream": "^1.0.3",
+        "parents": "^1.0.0",
+        "readable-stream": "^2.0.2",
+        "resolve": "^1.4.0",
+        "stream-combiner2": "^1.1.1",
+        "subarg": "^1.0.0",
+        "through2": "^2.0.0",
+        "xtend": "^4.0.0"
+      },
+      "bin": {
+        "module-deps": "bin/cmd.js"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+    },
+    "node_modules/normalize-package-data": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
+      "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
+      "dev": true,
+      "dependencies": {
+        "hosted-git-info": "^2.1.4",
+        "resolve": "^1.10.0",
+        "semver": "2 || 3 || 4 || 5",
+        "validate-npm-package-license": "^3.0.1"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.7.0.tgz",
+      "integrity": "sha512-a7pEHdh1xKIAgTySUGgLMx/xwDZskN1Ud6egYYN3EdRW4ZMPNEDUTF+hwy2LUC+Bl+SyLXANnwz/jyh/qutKUw==",
+      "dev": true
+    },
+    "node_modules/object-is": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.0.2.tgz",
+      "integrity": "sha512-Epah+btZd5wrrfjkJZq1AOB9O6OxUQto45hzFd7lXGrpHPGE0W1k+426yrZV+k6NJOzLNNW/nVsmZdIWsAqoOQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/object-keys": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/object.assign": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.0.tgz",
+      "integrity": "sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==",
+      "dev": true,
+      "dependencies": {
+        "define-properties": "^1.1.2",
+        "function-bind": "^1.1.1",
+        "has-symbols": "^1.0.0",
+        "object-keys": "^1.0.11"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dev": true,
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/openapi-sampler": {
+      "version": "1.0.0-beta.15",
+      "resolved": "https://registry.npmjs.org/openapi-sampler/-/openapi-sampler-1.0.0-beta.15.tgz",
+      "integrity": "sha512-wUD/vD3iBHKik/sME3uwUu4X3HFA53rDrPcVvLzgEELjHLbnTpSYfm4Jo9qZT1dPfBRowAnrF/VRQfOjL5QRAw==",
+      "dependencies": {
+        "json-pointer": "^0.6.0"
+      }
+    },
+    "node_modules/os-browserify": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.3.0.tgz",
+      "integrity": "sha1-hUNzx/XCMVkU/Jv8a9gjj92h7Cc=",
+      "dev": true
+    },
+    "node_modules/pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+      "dev": true
+    },
+    "node_modules/parents": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parents/-/parents-1.0.1.tgz",
+      "integrity": "sha1-/t1NK/GTp3dF/nHjcdc8MwfZx1E=",
+      "dev": true,
+      "dependencies": {
+        "path-platform": "~0.11.15"
+      }
+    },
+    "node_modules/parse-asn1": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.5.tgz",
+      "integrity": "sha512-jkMYn1dcJqF6d5CpU689bq7w/b5ALS9ROVSpQDPrZsqqesUJii9qutvoT5ltGedNXMO2e16YUWIghG9KxaViTQ==",
+      "dev": true,
+      "dependencies": {
+        "asn1.js": "^4.0.0",
+        "browserify-aes": "^1.0.0",
+        "create-hash": "^1.1.0",
+        "evp_bytestokey": "^1.0.0",
+        "pbkdf2": "^3.0.3",
+        "safe-buffer": "^5.1.1"
+      }
+    },
+    "node_modules/parse-json": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
+      "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+      "dev": true,
+      "dependencies": {
+        "error-ex": "^1.2.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/parse-ms": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parse-ms/-/parse-ms-1.0.1.tgz",
+      "integrity": "sha1-VjRtR0nXjyNDDKDHE4UK75GqNh0=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/path-browserify": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.1.tgz",
+      "integrity": "sha512-BapA40NHICOS+USX9SN4tyhq+A2RrN/Ws5F0Z5aMHDp98Fl86lX8Oti8B7uN93L4Ifv4fHOEA+pQw87gmMO/lQ==",
+      "dev": true
+    },
+    "node_modules/path-exists": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
+      "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
+      "dev": true,
+      "dependencies": {
+        "pinkie-promise": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/path-parse": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
+      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
+      "dev": true
+    },
+    "node_modules/path-platform": {
+      "version": "0.11.15",
+      "resolved": "https://registry.npmjs.org/path-platform/-/path-platform-0.11.15.tgz",
+      "integrity": "sha1-6GQhf3TDaFDwhSt43Hv31KVyG/I=",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/path-type": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
+      "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
+      "dev": true,
+      "dependencies": {
+        "graceful-fs": "^4.1.2",
+        "pify": "^2.0.0",
+        "pinkie-promise": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/pause-stream": {
+      "version": "0.0.11",
+      "resolved": "https://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz",
+      "integrity": "sha1-/lo0sMvOErWqaitAPuLnO2AvFEU=",
+      "dependencies": {
+        "through": "~2.3"
+      }
+    },
+    "node_modules/pbkdf2": {
+      "version": "3.0.17",
+      "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.17.tgz",
+      "integrity": "sha512-U/il5MsrZp7mGg3mSQfn742na2T+1/vHDCG5/iTI3X9MKUuYUZVLQhyRsg06mCgDBTd57TxzgZt7P+fYfjRLtA==",
+      "dev": true,
+      "dependencies": {
+        "create-hash": "^1.1.2",
+        "create-hmac": "^1.1.4",
+        "ripemd160": "^2.0.1",
+        "safe-buffer": "^5.0.1",
+        "sha.js": "^2.4.8"
+      },
+      "engines": {
+        "node": ">=0.12"
+      }
+    },
+    "node_modules/pify": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+      "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/pinkie": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-1.0.0.tgz",
+      "integrity": "sha1-Wkfyi6EBXQIBvae/DzWOR77Ix+Q=",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/pinkie-promise": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+      "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+      "dependencies": {
+        "pinkie": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/pinkie-promise/node_modules/pinkie": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
+      "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/plur": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/plur/-/plur-1.0.0.tgz",
+      "integrity": "sha1-24XGgU9eXlo7Se/CjWBP7GKXUVY=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.3.0.tgz",
+      "integrity": "sha512-kXtO4s0Lz/DW/IJ9QdWhAf7/NmPWQXkFr/r/WkR3vyI+0v8amTDxiaQSLzs8NBlytfLWX/7uQUMIW677yLKl4w==",
+      "dev": true,
+      "bin": {
+        "prettier": "bin-prettier.js"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/pretty-ms": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-1.4.0.tgz",
+      "integrity": "sha1-aQ1VY3lXwMU/gIaoEK23R4Jamg8=",
+      "dev": true,
+      "dependencies": {
+        "get-stdin": "^4.0.1",
+        "is-finite": "^1.0.1",
+        "meow": "^3.3.0",
+        "parse-ms": "^1.0.0",
+        "plur": "^1.0.0"
+      },
+      "bin": {
+        "pretty-ms": "cli.js"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/process": {
+      "version": "0.11.10",
+      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+      "integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI=",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
+    "node_modules/process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "dev": true
+    },
+    "node_modules/public-encrypt": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-4.0.3.tgz",
+      "integrity": "sha512-zVpa8oKZSz5bTMTFClc1fQOnyyEzpl5ozpi1B5YcvBrdohMjH2rfsBtyXcuNuwjsDIXmBYlF2N5FlJYhR29t8Q==",
+      "dev": true,
+      "dependencies": {
+        "bn.js": "^4.1.0",
+        "browserify-rsa": "^4.0.0",
+        "create-hash": "^1.1.0",
+        "parse-asn1": "^5.0.0",
+        "randombytes": "^2.0.1",
+        "safe-buffer": "^5.1.2"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/querystring": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
+      "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.4.x"
+      }
+    },
+    "node_modules/querystring-es3": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/querystring-es3/-/querystring-es3-0.2.1.tgz",
+      "integrity": "sha1-nsYfeQSYdXB9aUFFlv2Qek1xHnM=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.4.x"
+      }
+    },
+    "node_modules/randombytes": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
+      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
+      "dev": true,
+      "dependencies": {
+        "safe-buffer": "^5.1.0"
+      }
+    },
+    "node_modules/randomfill": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/randomfill/-/randomfill-1.0.4.tgz",
+      "integrity": "sha512-87lcbR8+MhcWcUiQ+9e+Rwx8MyR2P7qnt15ynUlbm3TU/fjbgz4GsvfSUDTemtCCtVCqb4ZcEFlyPNTh9bBTLw==",
+      "dev": true,
+      "dependencies": {
+        "randombytes": "^2.0.5",
+        "safe-buffer": "^5.1.0"
+      }
+    },
+    "node_modules/read-only-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/read-only-stream/-/read-only-stream-2.0.0.tgz",
+      "integrity": "sha1-JyT9aoET1zdkrCiNQ4YnDB2/F/A=",
+      "dev": true,
+      "dependencies": {
+        "readable-stream": "^2.0.2"
+      }
+    },
+    "node_modules/read-pkg": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
+      "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
+      "dev": true,
+      "dependencies": {
+        "load-json-file": "^1.0.0",
+        "normalize-package-data": "^2.3.2",
+        "path-type": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/read-pkg-up": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
+      "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
+      "dev": true,
+      "dependencies": {
+        "find-up": "^1.0.0",
+        "read-pkg": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "2.3.7",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+      "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+      "dev": true,
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/readable-stream/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true
+    },
+    "node_modules/readable-stream/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dev": true,
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "node_modules/redent": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
+      "integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
+      "dev": true,
+      "dependencies": {
+        "indent-string": "^2.1.0",
+        "strip-indent": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/regexp.prototype.flags": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.3.0.tgz",
+      "integrity": "sha512-2+Q0C5g951OlYlJz6yu5/M33IcsESLlLfsyIaLJaG4FA2r4yP8MvVMJUUP/fVBkSpbbbZlS5gynbEWLipiiXiQ==",
+      "dev": true,
+      "dependencies": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.0-next.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/repeating": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
+      "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
+      "dev": true,
+      "dependencies": {
+        "is-finite": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/resolve": {
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.15.1.tgz",
+      "integrity": "sha512-84oo6ZTtoTUpjgNEr5SJyzQhzL72gaRodsSfyxC/AXRvwu0Yse9H8eF9IpGo7b8YetZhlI6v7ZQ6bKBFV/6S7w==",
+      "dev": true,
+      "dependencies": {
+        "path-parse": "^1.0.6"
+      }
+    },
+    "node_modules/resumer": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/resumer/-/resumer-0.0.0.tgz",
+      "integrity": "sha1-8ej0YeQGS6Oegq883CqMiT0HZ1k=",
+      "dev": true,
+      "dependencies": {
+        "through": "~2.3.4"
+      }
+    },
+    "node_modules/ripemd160": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.2.tgz",
+      "integrity": "sha512-ii4iagi25WusVoiC4B4lq7pbXfAp3D9v5CwfkY33vffw2+pkDjY1D8GaN7spsxvCSx8dkPqOZCEZyfxcmJG2IA==",
+      "dev": true,
+      "dependencies": {
+        "hash-base": "^3.0.0",
+        "inherits": "^2.0.1"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.0.tgz",
+      "integrity": "sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg==",
+      "dev": true
+    },
+    "node_modules/semver": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver"
+      }
+    },
+    "node_modules/sha.js": {
+      "version": "2.4.11",
+      "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
+      "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
+      "dev": true,
+      "dependencies": {
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      },
+      "bin": {
+        "sha.js": "bin.js"
+      }
+    },
+    "node_modules/shasum": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/shasum/-/shasum-1.0.2.tgz",
+      "integrity": "sha1-5wEjENj0F/TetXEhUOVni4euVl8=",
+      "dev": true,
+      "dependencies": {
+        "json-stable-stringify": "~0.0.0",
+        "sha.js": "~2.4.4"
+      }
+    },
+    "node_modules/shasum-object": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/shasum-object/-/shasum-object-1.0.0.tgz",
+      "integrity": "sha512-Iqo5rp/3xVi6M4YheapzZhhGPVs0yZwHj7wvwQ1B9z8H6zk+FEnI7y3Teq7qwnekfEhu8WmG2z0z4iWZaxLWVg==",
+      "dev": true,
+      "dependencies": {
+        "fast-safe-stringify": "^2.0.7"
+      }
+    },
+    "node_modules/shell-quote": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.7.2.tgz",
+      "integrity": "sha512-mRz/m/JVscCrkMyPqHc/bczi3OQHkLTqXHEFu0zDhK/qfv3UcOA4SVmRCLmos4bhjr9ekVQubj/R7waKapmiQg==",
+      "dev": true
+    },
+    "node_modules/signal-exit": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz",
+      "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==",
+      "dev": true
+    },
+    "node_modules/simple-concat": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.0.tgz",
+      "integrity": "sha1-c0TLuLbib7J9ZrL8hvn21Zl1IcY=",
+      "dev": true
+    },
+    "node_modules/source-map": {
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+      "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/source-map-support": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.16.tgz",
+      "integrity": "sha512-efyLRJDr68D9hBBNIPWFjhpFzURh+KJykQwvMyW5UiZzYwoF6l4YMMDIJJEyFWxWCqfyxLzz6tSfUFR+kXXsVQ==",
+      "dev": true,
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
+      }
+    },
+    "node_modules/source-map-support/node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/spdx-correct": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.1.tgz",
+      "integrity": "sha512-cOYcUWwhCuHCXi49RhFRCyJEK3iPj1Ziz9DpViV3tbZOwXD49QzIN3MpOLJNxh2qwq2lJJZaKMVw9qNi4jTC0w==",
+      "dev": true,
+      "dependencies": {
+        "spdx-expression-parse": "^3.0.0",
+        "spdx-license-ids": "^3.0.0"
+      }
+    },
+    "node_modules/spdx-exceptions": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.3.0.tgz",
+      "integrity": "sha512-/tTrYOC7PPI1nUAgx34hUpqXuyJG+DTHJTnIULG4rDygi4xu/tfgmq1e1cIRwRzwZgo4NLySi+ricLkZkw4i5A==",
+      "dev": true
+    },
+    "node_modules/spdx-expression-parse": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz",
+      "integrity": "sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==",
+      "dev": true,
+      "dependencies": {
+        "spdx-exceptions": "^2.1.0",
+        "spdx-license-ids": "^3.0.0"
+      }
+    },
+    "node_modules/spdx-license-ids": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.8.tgz",
+      "integrity": "sha512-NDgA96EnaLSvtbM7trJj+t1LUR3pirkDCcz9nOUlPb5DMBGsH7oES6C3hs3j7R9oHEa1EMvReS/BUAIT5Tcr0g==",
+      "dev": true
+    },
+    "node_modules/split": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/split/-/split-0.3.3.tgz",
+      "integrity": "sha1-zQ7qXmOiEd//frDwkcQTPi0N0o8=",
+      "dependencies": {
+        "through": "2"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/stream-browserify": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-2.0.2.tgz",
+      "integrity": "sha512-nX6hmklHs/gr2FuxYDltq8fJA1GDlxKQCz8O/IM4atRqBH8OORmBNgfvW5gG10GT/qQ9u0CzIvr2X5Pkt6ntqg==",
+      "dev": true,
+      "dependencies": {
+        "inherits": "~2.0.1",
+        "readable-stream": "^2.0.2"
+      }
+    },
+    "node_modules/stream-combiner": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.0.4.tgz",
+      "integrity": "sha1-TV5DPBhSYd3mI8o/RMWGvPXErRQ=",
+      "dependencies": {
+        "duplexer": "~0.1.1"
+      }
+    },
+    "node_modules/stream-combiner2": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/stream-combiner2/-/stream-combiner2-1.1.1.tgz",
+      "integrity": "sha1-+02KFCDqNidk4hrUeAOXvry0HL4=",
+      "dev": true,
+      "dependencies": {
+        "duplexer2": "~0.1.0",
+        "readable-stream": "^2.0.2"
+      }
+    },
+    "node_modules/stream-http": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/stream-http/-/stream-http-3.1.0.tgz",
+      "integrity": "sha512-cuB6RgO7BqC4FBYzmnvhob5Do3wIdIsXAgGycHJnW+981gHqoYcYz9lqjJrk8WXRddbwPuqPYRl+bag6mYv4lw==",
+      "dev": true,
+      "dependencies": {
+        "builtin-status-codes": "^3.0.0",
+        "inherits": "^2.0.1",
+        "readable-stream": "^3.0.6",
+        "xtend": "^4.0.0"
+      }
+    },
+    "node_modules/stream-http/node_modules/readable-stream": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+      "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+      "dev": true,
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/stream-splicer": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/stream-splicer/-/stream-splicer-2.0.1.tgz",
+      "integrity": "sha512-Xizh4/NPuYSyAXyT7g8IvdJ9HJpxIGL9PjyhtywCZvvP0OPIdqyrr4dMikeuvY8xahpdKEBlBTySe583totajg==",
+      "dev": true,
+      "dependencies": {
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.0.2"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "dev": true,
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/string.prototype.trim": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.1.tgz",
+      "integrity": "sha512-MjGFEeqixw47dAMFMtgUro/I0+wNqZB5GKXGt1fFr24u3TzDXCPu7J9Buppzoe3r/LqkSDLDDJzE15RGWDGAVw==",
+      "dev": true,
+      "dependencies": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.0-next.1",
+        "function-bind": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/string.prototype.trimend": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.0.tgz",
+      "integrity": "sha512-EEJnGqa/xNfIg05SxiPSqRS7S9qwDhYts1TSLR1BQfYUfPe1stofgGKvwERK9+9yf+PpfBMlpBaCHucXGPQfUA==",
+      "dev": true,
+      "dependencies": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.5"
+      }
+    },
+    "node_modules/string.prototype.trimleft": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimleft/-/string.prototype.trimleft-2.1.2.tgz",
+      "integrity": "sha512-gCA0tza1JBvqr3bfAIFJGqfdRTyPae82+KTnm3coDXkZN9wnuW3HjGgN386D7hfv5CHQYCI022/rJPVlqXyHSw==",
+      "dev": true,
+      "dependencies": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.5",
+        "string.prototype.trimstart": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/string.prototype.trimright": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimright/-/string.prototype.trimright-2.1.2.tgz",
+      "integrity": "sha512-ZNRQ7sY3KroTaYjRS6EbNiiHrOkjihL9aQE/8gfQ4DtAC/aEBRHFJa44OmoWxGGqXuJlfKkZW4WcXErGr+9ZFg==",
+      "dev": true,
+      "dependencies": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.5",
+        "string.prototype.trimend": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/string.prototype.trimstart": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.0.tgz",
+      "integrity": "sha512-iCP8g01NFYiiBOnwG1Xc3WZLyoo+RuBymwIlWncShXDDJYWN6DbnM3odslBJdgCdRlq94B5s63NWAZlcn2CS4w==",
+      "dev": true,
+      "dependencies": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.5"
+      }
+    },
+    "node_modules/stringify-object": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/stringify-object/-/stringify-object-3.3.0.tgz",
+      "integrity": "sha512-rHqiFh1elqCQ9WPLIC8I0Q/g/wj5J1eMkyoiD6eoQApWHP0FtlK7rqnhmabL5VUY9JQCcqwwvlOaSuutekgyrw==",
+      "dependencies": {
+        "get-own-enumerable-property-symbols": "^3.0.0",
+        "is-obj": "^1.0.1",
+        "is-regexp": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+      "dependencies": {
+        "ansi-regex": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/strip-bom": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+      "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+      "dev": true,
+      "dependencies": {
+        "is-utf8": "^0.2.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/strip-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
+      "integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
+      "dev": true,
+      "dependencies": {
+        "get-stdin": "^4.0.1"
+      },
+      "bin": {
+        "strip-indent": "cli.js"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/subarg": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/subarg/-/subarg-1.0.0.tgz",
+      "integrity": "sha1-9izxdYHplrSPyWVpn1TAauJouNI=",
+      "dev": true,
+      "dependencies": {
+        "minimist": "^1.1.0"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+      "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/syntax-error": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/syntax-error/-/syntax-error-1.4.0.tgz",
+      "integrity": "sha512-YPPlu67mdnHGTup2A8ff7BC2Pjq0e0Yp/IyTFN03zWO0RcK07uLcbi7C2KpGR2FvWbaB0+bfE27a+sBKebSo7w==",
+      "dev": true,
+      "dependencies": {
+        "acorn-node": "^1.2.0"
+      }
+    },
+    "node_modules/tap-parser": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/tap-parser/-/tap-parser-0.7.0.tgz",
+      "integrity": "sha1-coph1kaApbSNXb2dvQpNSPXDW8s=",
+      "dev": true,
+      "dependencies": {
+        "inherits": "~2.0.1",
+        "minimist": "^0.2.0",
+        "readable-stream": "~1.1.11"
+      },
+      "bin": {
+        "tap-parser": "bin/cmd.js"
+      }
+    },
+    "node_modules/tap-parser/node_modules/isarray": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+      "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+      "dev": true
+    },
+    "node_modules/tap-parser/node_modules/minimist": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.2.1.tgz",
+      "integrity": "sha512-GY8fANSrTMfBVfInqJAY41QkOM+upUTytK1jZ0c8+3HdHrJxBJ3rF5i9moClXTE8uUSnUo8cAsCoxDXvSY4DHg==",
+      "dev": true
+    },
+    "node_modules/tap-parser/node_modules/readable-stream": {
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+      "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
+      "dev": true,
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.1",
+        "isarray": "0.0.1",
+        "string_decoder": "~0.10.x"
+      }
+    },
+    "node_modules/tap-parser/node_modules/string_decoder": {
+      "version": "0.10.31",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+      "dev": true
+    },
+    "node_modules/tap-spec": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/tap-spec/-/tap-spec-2.2.2.tgz",
+      "integrity": "sha1-FK2zmgX5ZMgR73B1lzINO7K7K9o=",
+      "dev": true,
+      "dependencies": {
+        "chalk": "^1.0.0",
+        "duplexer": "^0.1.1",
+        "pretty-ms": "^1.0.0",
+        "tap-parser": "^0.7.0",
+        "through2": "^0.6.3"
+      },
+      "bin": {
+        "tap-spec": "bin/cmd.js",
+        "tspec": "bin/cmd.js"
+      }
+    },
+    "node_modules/tap-spec/node_modules/isarray": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+      "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+      "dev": true
+    },
+    "node_modules/tap-spec/node_modules/readable-stream": {
+      "version": "1.0.34",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+      "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
+      "dev": true,
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.1",
+        "isarray": "0.0.1",
+        "string_decoder": "~0.10.x"
+      }
+    },
+    "node_modules/tap-spec/node_modules/string_decoder": {
+      "version": "0.10.31",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+      "dev": true
+    },
+    "node_modules/tap-spec/node_modules/through2": {
+      "version": "0.6.5",
+      "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
+      "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
+      "dev": true,
+      "dependencies": {
+        "readable-stream": ">=1.0.33-1 <1.1.0-0",
+        "xtend": ">=4.0.0 <4.1.0-0"
+      }
+    },
+    "node_modules/tape": {
+      "version": "4.13.2",
+      "resolved": "https://registry.npmjs.org/tape/-/tape-4.13.2.tgz",
+      "integrity": "sha512-waWwC/OqYVE9TS6r1IynlP2sEdk4Lfo6jazlgkuNkPTHIbuG2BTABIaKdlQWwPeB6Oo4ksZ1j33Yt0NTOAlYMQ==",
+      "dev": true,
+      "dependencies": {
+        "deep-equal": "~1.1.1",
+        "defined": "~1.0.0",
+        "dotignore": "~0.1.2",
+        "for-each": "~0.3.3",
+        "function-bind": "~1.1.1",
+        "glob": "~7.1.6",
+        "has": "~1.0.3",
+        "inherits": "~2.0.4",
+        "is-regex": "~1.0.5",
+        "minimist": "~1.2.0",
+        "object-inspect": "~1.7.0",
+        "resolve": "~1.15.1",
+        "resumer": "~0.0.0",
+        "string.prototype.trim": "~1.2.1",
+        "through": "~2.3.8"
+      },
+      "bin": {
+        "tape": "bin/tape"
+      }
+    },
+    "node_modules/terser": {
+      "version": "3.17.0",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-3.17.0.tgz",
+      "integrity": "sha512-/FQzzPJmCpjAH9Xvk2paiWrFq+5M6aVOf+2KRbwhByISDX/EujxsK+BAvrhb6H+2rtrLCHK9N01wO014vrIwVQ==",
+      "dev": true,
+      "dependencies": {
+        "commander": "^2.19.0",
+        "source-map": "~0.6.1",
+        "source-map-support": "~0.5.10"
+      },
+      "bin": {
+        "terser": "bin/uglifyjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/terser/node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/through": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
+    },
+    "node_modules/through2": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
+      "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
+      "dev": true,
+      "dependencies": {
+        "readable-stream": "~2.3.6",
+        "xtend": "~4.0.1"
+      }
+    },
+    "node_modules/timers-browserify": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-1.4.2.tgz",
+      "integrity": "sha1-ycWLV1voQHN1y14kYtrO50NZ9B0=",
+      "dev": true,
+      "dependencies": {
+        "process": "~0.11.0"
+      },
+      "engines": {
+        "node": ">=0.6.0"
+      }
+    },
+    "node_modules/trim-newlines": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
+      "integrity": "sha1-WIeWa7WCpFA6QetST301ARgVphM=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/tty-browserify": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.1.tgz",
+      "integrity": "sha512-C3TaO7K81YvjCgQH9Q1S3R3P3BtN3RIM8n+OvX4il1K1zgE8ZhI0op7kClgkxtutIE8hQrcrHBXvIheqKUUCxw==",
+      "dev": true
+    },
+    "node_modules/typedarray": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
+      "dev": true
+    },
+    "node_modules/uglifyify": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/uglifyify/-/uglifyify-5.0.2.tgz",
+      "integrity": "sha512-NcSk6pgoC+IgwZZ2tVLVHq+VNKSvLPlLkF5oUiHPVOJI0s/OlSVYEGXG9PCAH0hcyFZLyvt4KBdPAQBRlVDn1Q==",
+      "dev": true,
+      "dependencies": {
+        "convert-source-map": "~1.1.0",
+        "minimatch": "^3.0.2",
+        "terser": "^3.7.5",
+        "through": "~2.3.4",
+        "xtend": "^4.0.1"
+      }
+    },
+    "node_modules/umd": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/umd/-/umd-3.0.3.tgz",
+      "integrity": "sha512-4IcGSufhFshvLNcMCV80UnQVlZ5pMOC8mvNPForqwA4+lzYQuetTESLDQkeLmihq8bRcnpbQa48Wb8Lh16/xow==",
+      "dev": true,
+      "bin": {
+        "umd": "bin/cli.js"
+      }
+    },
+    "node_modules/undeclared-identifiers": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/undeclared-identifiers/-/undeclared-identifiers-1.1.3.tgz",
+      "integrity": "sha512-pJOW4nxjlmfwKApE4zvxLScM/njmwj/DiUBv7EabwE4O8kRUy+HIwxQtZLBPll/jx1LJyBcqNfB3/cpv9EZwOw==",
+      "dev": true,
+      "dependencies": {
+        "acorn-node": "^1.3.0",
+        "dash-ast": "^1.0.0",
+        "get-assigned-identifiers": "^1.2.0",
+        "simple-concat": "^1.0.0",
+        "xtend": "^4.0.1"
+      },
+      "bin": {
+        "undeclared-identifiers": "bin.js"
+      }
+    },
+    "node_modules/uri-js": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
+      "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
+      "dependencies": {
+        "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/url": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/url/-/url-0.11.0.tgz",
+      "integrity": "sha1-ODjpfPxgUh63PFJajlW/3Z4uKPE=",
+      "dev": true,
+      "dependencies": {
+        "punycode": "1.3.2",
+        "querystring": "0.2.0"
+      }
+    },
+    "node_modules/url/node_modules/punycode": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
+      "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0=",
+      "dev": true
+    },
+    "node_modules/util": {
+      "version": "0.10.4",
+      "resolved": "https://registry.npmjs.org/util/-/util-0.10.4.tgz",
+      "integrity": "sha512-0Pm9hTQ3se5ll1XihRic3FDIku70C+iHUdT/W926rSgHV5QgXsYbKZN8MSC3tJtSkhuROzvsQjAaFENRXr+19A==",
+      "dev": true,
+      "dependencies": {
+        "inherits": "2.0.3"
+      }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+      "dev": true
+    },
+    "node_modules/util/node_modules/inherits": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+      "dev": true
+    },
+    "node_modules/validate-npm-package-license": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
+      "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
+      "dev": true,
+      "dependencies": {
+        "spdx-correct": "^3.0.0",
+        "spdx-expression-parse": "^3.0.0"
+      }
+    },
+    "node_modules/vm-browserify": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-1.1.2.tgz",
+      "integrity": "sha512-2ham8XPWTONajOR0ohOKOHXkm3+gaBmGut3SRuu75xLd/RRaY6vqgh8NBYYk7+RW3u5AtzPQZG8F10LHkl0lAQ==",
+      "dev": true
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true
+    },
+    "node_modules/xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.4"
+      }
+    }
+  },
+  "dependencies": {
     "acorn": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.1.1.tgz",
@@ -57,6 +2719,12 @@
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
       "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+    },
+    "array-find-index": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
+      "integrity": "sha1-3wEKoSh+Fku9pvlyOwqWoexBh6E=",
+      "dev": true
     },
     "asn1.js": {
       "version": "4.10.1",
@@ -144,9 +2812,9 @@
       "integrity": "sha512-erYug8XoqzU3IfcU8fUgyHqyOXqIE4tUTTQ+7mqUjQlvnXkOO6OlT9c/ZoJVHYoAaqGxr09CN53G7XIsO4KtWA==",
       "dev": true,
       "requires": {
-        "JSONStream": "^1.0.3",
         "combine-source-map": "~0.8.0",
         "defined": "^1.0.0",
+        "JSONStream": "^1.0.3",
         "safe-buffer": "^5.1.1",
         "through2": "^2.0.0",
         "umd": "^3.0.0"
@@ -175,7 +2843,6 @@
       "integrity": "sha512-EQX0h59Pp+0GtSRb5rL6OTfrttlzv+uyaUVlK6GX3w11SQ0jKPKyjC/54RhPR2ib2KmfcELM06e8FxcI5XNU2A==",
       "dev": true,
       "requires": {
-        "JSONStream": "^1.0.3",
         "assert": "^1.4.0",
         "browser-pack": "^6.0.1",
         "browser-resolve": "^1.11.0",
@@ -197,6 +2864,7 @@
         "https-browserify": "^1.0.0",
         "inherits": "~2.0.1",
         "insert-module-globals": "^7.0.0",
+        "JSONStream": "^1.0.3",
         "labeled-stream-splicer": "^2.0.0",
         "mkdirp-classic": "^0.5.2",
         "module-deps": "^6.0.0",
@@ -320,12 +2988,6 @@
       "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
       "dev": true
     },
-    "buffer-shims": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
-      "integrity": "sha1-mXjOMXOIxkmth5MCjDR37wRKi1E=",
-      "dev": true
-    },
     "buffer-xor": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz",
@@ -343,6 +3005,22 @@
       "resolved": "https://registry.npmjs.org/cached-path-relative/-/cached-path-relative-1.0.2.tgz",
       "integrity": "sha512-5r2GqsoEb4qMTTN9J+WzXfjov+hjxT+j3u5K+kIVNIwAd99DLCJE9pBIMP1qVeybV6JiijL385Oz0DcYxfbOIg==",
       "dev": true
+    },
+    "camelcase": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
+      "integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8=",
+      "dev": true
+    },
+    "camelcase-keys": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
+      "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
+      "dev": true,
+      "requires": {
+        "camelcase": "^2.0.0",
+        "map-obj": "^1.0.0"
+      }
     },
     "chalk": {
       "version": "1.1.3",
@@ -489,6 +3167,15 @@
         "randomfill": "^1.0.3"
       }
     },
+    "currently-unhandled": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
+      "integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
+      "dev": true,
+      "requires": {
+        "array-find-index": "^1.0.1"
+      }
+    },
     "dash-ast": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/dash-ast/-/dash-ast-1.0.0.tgz",
@@ -502,6 +3189,12 @@
       "requires": {
         "ms": "2.0.0"
       }
+    },
+    "decamelize": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+      "dev": true
     },
     "deep-equal": {
       "version": "1.1.1",
@@ -611,18 +3304,35 @@
       }
     },
     "elliptic": {
-      "version": "6.5.3",
-      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.3.tgz",
-      "integrity": "sha512-IMqzv5wNQf+E6aHeIqATs0tOLeOTwj1QKbRcS3jBbYkl5oLAserA8yJTT7/VyHUYG91PRmPyeQDObKLPpeS4dw==",
+      "version": "6.5.4",
+      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.4.tgz",
+      "integrity": "sha512-iLhC6ULemrljPZb+QutR5TQGB+pdW6KGD5RSegS+8sorOZT+rdQFbsQFJgvN3eRqNALqJer4oQ16YvJHlU8hzQ==",
       "dev": true,
       "requires": {
-        "bn.js": "^4.4.0",
-        "brorand": "^1.0.1",
+        "bn.js": "^4.11.9",
+        "brorand": "^1.1.0",
         "hash.js": "^1.0.0",
-        "hmac-drbg": "^1.0.0",
-        "inherits": "^2.0.1",
-        "minimalistic-assert": "^1.0.0",
-        "minimalistic-crypto-utils": "^1.0.0"
+        "hmac-drbg": "^1.0.1",
+        "inherits": "^2.0.4",
+        "minimalistic-assert": "^1.0.1",
+        "minimalistic-crypto-utils": "^1.0.1"
+      },
+      "dependencies": {
+        "bn.js": {
+          "version": "4.12.0",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+          "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
+          "dev": true
+        }
+      }
+    },
+    "error-ex": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
+      "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
+      "dev": true,
+      "requires": {
+        "is-arrayish": "^0.2.1"
       }
     },
     "es-abstract": {
@@ -706,14 +3416,14 @@
       "integrity": "sha512-Utm6CdzT+6xsDk2m8S6uL8VHxNwI6Jub+e9NYTcAms28T84pTa25GJQV9j0CY0N1rM8hK4x6grpF2BQf+2qwVA==",
       "dev": true
     },
-    "figures": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
-      "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
+    "find-up": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
+      "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
       "dev": true,
       "requires": {
-        "escape-string-regexp": "^1.0.5",
-        "object-assign": "^4.1.0"
+        "path-exists": "^2.0.0",
+        "pinkie-promise": "^2.0.0"
       }
     },
     "for-each": {
@@ -794,6 +3504,12 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/get-own-enumerable-property-symbols/-/get-own-enumerable-property-symbols-3.0.2.tgz",
       "integrity": "sha512-I0UBV/XOz1XkIJHEUDMZAbzCThU/H8DxmSfmdGcKPnVhu2VfFqr34jr9777IyaTYvxjedWhqVIilEDsCdP5G6g=="
+    },
+    "get-stdin": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
+      "integrity": "sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4=",
+      "dev": true
     },
     "glob": {
       "version": "7.1.6",
@@ -882,6 +3598,12 @@
         "minimalistic-crypto-utils": "^1.0.1"
       }
     },
+    "hosted-git-info": {
+      "version": "2.8.9",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
+      "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
+      "dev": true
+    },
     "htmlescape": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/htmlescape/-/htmlescape-1.1.1.tgz",
@@ -917,6 +3639,15 @@
       "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg==",
       "dev": true
     },
+    "indent-string": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
+      "integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
+      "dev": true,
+      "requires": {
+        "repeating": "^2.0.0"
+      }
+    },
     "inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
@@ -948,11 +3679,11 @@
       "integrity": "sha512-VE6NlW+WGn2/AeOMd496AHFYmE7eLKkUY6Ty31k4og5vmA3Fjuwe9v6ifH6Xx/Hz27QvdoMoviw1/pqWRB09Sw==",
       "dev": true,
       "requires": {
-        "JSONStream": "^1.0.3",
         "acorn-node": "^1.5.2",
         "combine-source-map": "^0.8.0",
         "concat-stream": "^1.6.1",
         "is-buffer": "^1.1.0",
+        "JSONStream": "^1.0.3",
         "path-is-absolute": "^1.0.1",
         "process": "~0.11.0",
         "through2": "^2.0.0",
@@ -964,6 +3695,12 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.0.4.tgz",
       "integrity": "sha512-xPh0Rmt8NE65sNzvyUmWgI1tz3mKq74lGA0mL8LYZcoIzKOzDh6HmrYm3d18k60nHerC8A9Km8kYu87zfSFnLA==",
+      "dev": true
+    },
+    "is-arrayish": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
       "dev": true
     },
     "is-buffer": {
@@ -1018,6 +3755,12 @@
         "has-symbols": "^1.0.1"
       }
     },
+    "is-utf8": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
+      "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
+      "dev": true
+    },
     "isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
@@ -1025,9 +3768,9 @@
       "dev": true
     },
     "json-pointer": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/json-pointer/-/json-pointer-0.6.0.tgz",
-      "integrity": "sha1-jlAFUKaqxUZKRzN32leqbMIoKNc=",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/json-pointer/-/json-pointer-0.6.1.tgz",
+      "integrity": "sha512-3OvjqKdCBvH41DLpV4iSt6v2XhZXV1bPB4OROuknvUXI7ZQNofieCPkmE26stEJ9zdQuvIxDHCuYhfgxFAAs+Q==",
       "requires": {
         "foreach": "^2.0.4"
       }
@@ -1058,6 +3801,16 @@
       "integrity": "sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA=",
       "dev": true
     },
+    "JSONStream": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.5.tgz",
+      "integrity": "sha512-E+iruNOY8VV9s4JEbe1aNEm6MiszPRr/UfcHMz0TQh1BXSxHK+ASV1R6W4HpjBhSeS+54PIsAMCBmwD06LLsqQ==",
+      "dev": true,
+      "requires": {
+        "jsonparse": "^1.2.0",
+        "through": ">=2.2.7 <3"
+      }
+    },
     "labeled-stream-splicer": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/labeled-stream-splicer/-/labeled-stream-splicer-2.0.2.tgz",
@@ -1068,15 +3821,44 @@
         "stream-splicer": "^2.0.0"
       }
     },
+    "load-json-file": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+      "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.2",
+        "parse-json": "^2.2.0",
+        "pify": "^2.0.0",
+        "pinkie-promise": "^2.0.0",
+        "strip-bom": "^2.0.0"
+      }
+    },
     "lodash": {
-      "version": "4.17.19",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
-      "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ=="
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "lodash.memoize": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-3.0.4.tgz",
       "integrity": "sha1-LcvSwofLwKVcxCMovQxzYVDVPj8=",
+      "dev": true
+    },
+    "loud-rejection": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz",
+      "integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
+      "dev": true,
+      "requires": {
+        "currently-unhandled": "^0.4.1",
+        "signal-exit": "^3.0.0"
+      }
+    },
+    "map-obj": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
+      "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=",
       "dev": true
     },
     "map-stream": {
@@ -1093,6 +3875,24 @@
         "hash-base": "^3.0.0",
         "inherits": "^2.0.1",
         "safe-buffer": "^5.1.2"
+      }
+    },
+    "meow": {
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
+      "integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
+      "dev": true,
+      "requires": {
+        "camelcase-keys": "^2.0.0",
+        "decamelize": "^1.1.2",
+        "loud-rejection": "^1.0.0",
+        "map-obj": "^1.0.1",
+        "minimist": "^1.1.3",
+        "normalize-package-data": "^2.3.4",
+        "object-assign": "^4.0.1",
+        "read-pkg-up": "^1.0.1",
+        "redent": "^1.0.0",
+        "trim-newlines": "^1.0.0"
       }
     },
     "miller-rabin": {
@@ -1162,7 +3962,6 @@
       "integrity": "sha512-a9y6yDv5u5I4A+IPHTnqFxcaKr4p50/zxTjcQJaX2ws9tN/W6J6YXnEKhqRyPhl494dkcxx951onSKVezmI+3w==",
       "dev": true,
       "requires": {
-        "JSONStream": "^1.0.3",
         "browser-resolve": "^1.7.0",
         "cached-path-relative": "^1.0.2",
         "concat-stream": "~1.6.0",
@@ -1170,6 +3969,7 @@
         "detective": "^5.2.0",
         "duplexer2": "^0.1.2",
         "inherits": "^2.0.1",
+        "JSONStream": "^1.0.3",
         "parents": "^1.0.0",
         "readable-stream": "^2.0.2",
         "resolve": "^1.4.0",
@@ -1183,6 +3983,18 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+    },
+    "normalize-package-data": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
+      "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
+      "dev": true,
+      "requires": {
+        "hosted-git-info": "^2.1.4",
+        "resolve": "^1.10.0",
+        "semver": "2 || 3 || 4 || 5",
+        "validate-npm-package-license": "^3.0.1"
+      }
     },
     "object-assign": {
       "version": "4.1.1",
@@ -1272,6 +4084,15 @@
         "safe-buffer": "^5.1.1"
       }
     },
+    "parse-json": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
+      "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+      "dev": true,
+      "requires": {
+        "error-ex": "^1.2.0"
+      }
+    },
     "parse-ms": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parse-ms/-/parse-ms-1.0.1.tgz",
@@ -1283,6 +4104,15 @@
       "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.1.tgz",
       "integrity": "sha512-BapA40NHICOS+USX9SN4tyhq+A2RrN/Ws5F0Z5aMHDp98Fl86lX8Oti8B7uN93L4Ifv4fHOEA+pQw87gmMO/lQ==",
       "dev": true
+    },
+    "path-exists": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
+      "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
+      "dev": true,
+      "requires": {
+        "pinkie-promise": "^2.0.0"
+      }
     },
     "path-is-absolute": {
       "version": "1.0.1",
@@ -1301,6 +4131,17 @@
       "resolved": "https://registry.npmjs.org/path-platform/-/path-platform-0.11.15.tgz",
       "integrity": "sha1-6GQhf3TDaFDwhSt43Hv31KVyG/I=",
       "dev": true
+    },
+    "path-type": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
+      "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.2",
+        "pify": "^2.0.0",
+        "pinkie-promise": "^2.0.0"
+      }
     },
     "pause-stream": {
       "version": "0.0.11",
@@ -1322,6 +4163,12 @@
         "safe-buffer": "^5.0.1",
         "sha.js": "^2.4.8"
       }
+    },
+    "pify": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+      "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+      "dev": true
     },
     "pinkie": {
       "version": "1.0.0",
@@ -1349,13 +4196,21 @@
       "integrity": "sha1-24XGgU9eXlo7Se/CjWBP7GKXUVY=",
       "dev": true
     },
+    "prettier": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.3.0.tgz",
+      "integrity": "sha512-kXtO4s0Lz/DW/IJ9QdWhAf7/NmPWQXkFr/r/WkR3vyI+0v8amTDxiaQSLzs8NBlytfLWX/7uQUMIW677yLKl4w==",
+      "dev": true
+    },
     "pretty-ms": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-2.1.0.tgz",
-      "integrity": "sha1-QlfCVt8/sLRR1q/6qwIYhBJpgdw=",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-1.4.0.tgz",
+      "integrity": "sha1-aQ1VY3lXwMU/gIaoEK23R4Jamg8=",
       "dev": true,
       "requires": {
+        "get-stdin": "^4.0.1",
         "is-finite": "^1.0.1",
+        "meow": "^3.3.0",
         "parse-ms": "^1.0.0",
         "plur": "^1.0.0"
       }
@@ -1422,12 +4277,6 @@
         "safe-buffer": "^5.1.0"
       }
     },
-    "re-emitter": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/re-emitter/-/re-emitter-1.1.3.tgz",
-      "integrity": "sha1-+p4xn/3u6zWycpbvDz03TawvUqc=",
-      "dev": true
-    },
     "read-only-stream": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/read-only-stream/-/read-only-stream-2.0.0.tgz",
@@ -1435,6 +4284,27 @@
       "dev": true,
       "requires": {
         "readable-stream": "^2.0.2"
+      }
+    },
+    "read-pkg": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
+      "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
+      "dev": true,
+      "requires": {
+        "load-json-file": "^1.0.0",
+        "normalize-package-data": "^2.3.2",
+        "path-type": "^1.0.0"
+      }
+    },
+    "read-pkg-up": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
+      "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
+      "dev": true,
+      "requires": {
+        "find-up": "^1.0.0",
+        "read-pkg": "^1.0.0"
       }
     },
     "readable-stream": {
@@ -1469,6 +4339,16 @@
         }
       }
     },
+    "redent": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
+      "integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
+      "dev": true,
+      "requires": {
+        "indent-string": "^2.1.0",
+        "strip-indent": "^1.0.1"
+      }
+    },
     "regexp.prototype.flags": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.3.0.tgz",
@@ -1479,11 +4359,14 @@
         "es-abstract": "^1.17.0-next.1"
       }
     },
-    "repeat-string": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
-      "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
-      "dev": true
+    "repeating": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
+      "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
+      "dev": true,
+      "requires": {
+        "is-finite": "^1.0.0"
+      }
     },
     "resolve": {
       "version": "1.15.1",
@@ -1517,6 +4400,12 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.0.tgz",
       "integrity": "sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg==",
+      "dev": true
+    },
+    "semver": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
       "dev": true
     },
     "sha.js": {
@@ -1554,6 +4443,12 @@
       "integrity": "sha512-mRz/m/JVscCrkMyPqHc/bczi3OQHkLTqXHEFu0zDhK/qfv3UcOA4SVmRCLmos4bhjr9ekVQubj/R7waKapmiQg==",
       "dev": true
     },
+    "signal-exit": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz",
+      "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==",
+      "dev": true
+    },
     "simple-concat": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.0.tgz",
@@ -1583,6 +4478,38 @@
           "dev": true
         }
       }
+    },
+    "spdx-correct": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.1.tgz",
+      "integrity": "sha512-cOYcUWwhCuHCXi49RhFRCyJEK3iPj1Ziz9DpViV3tbZOwXD49QzIN3MpOLJNxh2qwq2lJJZaKMVw9qNi4jTC0w==",
+      "dev": true,
+      "requires": {
+        "spdx-expression-parse": "^3.0.0",
+        "spdx-license-ids": "^3.0.0"
+      }
+    },
+    "spdx-exceptions": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.3.0.tgz",
+      "integrity": "sha512-/tTrYOC7PPI1nUAgx34hUpqXuyJG+DTHJTnIULG4rDygi4xu/tfgmq1e1cIRwRzwZgo4NLySi+ricLkZkw4i5A==",
+      "dev": true
+    },
+    "spdx-expression-parse": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz",
+      "integrity": "sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==",
+      "dev": true,
+      "requires": {
+        "spdx-exceptions": "^2.1.0",
+        "spdx-license-ids": "^3.0.0"
+      }
+    },
+    "spdx-license-ids": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.8.tgz",
+      "integrity": "sha512-NDgA96EnaLSvtbM7trJj+t1LUR3pirkDCcz9nOUlPb5DMBGsH7oES6C3hs3j7R9oHEa1EMvReS/BUAIT5Tcr0g==",
+      "dev": true
     },
     "split": {
       "version": "0.3.3",
@@ -1655,6 +4582,15 @@
         "readable-stream": "^2.0.2"
       }
     },
+    "string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
     "string.prototype.trim": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.1.tgz",
@@ -1708,15 +4644,6 @@
         "es-abstract": "^1.17.5"
       }
     },
-    "string_decoder": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
-      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-      "dev": true,
-      "requires": {
-        "safe-buffer": "~5.2.0"
-      }
-    },
     "stringify-object": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/stringify-object/-/stringify-object-3.3.0.tgz",
@@ -1733,6 +4660,24 @@
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
       "requires": {
         "ansi-regex": "^2.0.0"
+      }
+    },
+    "strip-bom": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+      "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+      "dev": true,
+      "requires": {
+        "is-utf8": "^0.2.0"
+      }
+    },
+    "strip-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
+      "integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
+      "dev": true,
+      "requires": {
+        "get-stdin": "^4.0.1"
       }
     },
     "subarg": {
@@ -1758,79 +4703,96 @@
         "acorn-node": "^1.2.0"
       }
     },
-    "tap-out": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/tap-out/-/tap-out-2.1.0.tgz",
-      "integrity": "sha512-LJE+TBoVbOWhwdz4+FQk40nmbIuxJLqaGvj3WauQw3NYYU5TdjoV3C0x/yq37YAvVyi+oeBXmWnxWSjJ7IEyUw==",
+    "tap-parser": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/tap-parser/-/tap-parser-0.7.0.tgz",
+      "integrity": "sha1-coph1kaApbSNXb2dvQpNSPXDW8s=",
       "dev": true,
       "requires": {
-        "re-emitter": "1.1.3",
-        "readable-stream": "2.2.9",
-        "split": "1.0.0",
-        "trim": "0.0.1"
+        "inherits": "~2.0.1",
+        "minimist": "^0.2.0",
+        "readable-stream": "~1.1.11"
       },
       "dependencies": {
-        "process-nextick-args": {
-          "version": "1.0.7",
-          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-          "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+          "dev": true
+        },
+        "minimist": {
+          "version": "0.2.1",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.2.1.tgz",
+          "integrity": "sha512-GY8fANSrTMfBVfInqJAY41QkOM+upUTytK1jZ0c8+3HdHrJxBJ3rF5i9moClXTE8uUSnUo8cAsCoxDXvSY4DHg==",
           "dev": true
         },
         "readable-stream": {
-          "version": "2.2.9",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
-          "integrity": "sha1-z3jsb0ptHrQ9JkiMrJfwQudLf8g=",
+          "version": "1.1.14",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+          "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
           "dev": true,
           "requires": {
-            "buffer-shims": "~1.0.0",
             "core-util-is": "~1.0.0",
             "inherits": "~2.0.1",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~1.0.6",
-            "string_decoder": "~1.0.0",
-            "util-deprecate": "~1.0.1"
-          }
-        },
-        "safe-buffer": {
-          "version": "5.1.2",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-          "dev": true
-        },
-        "split": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/split/-/split-1.0.0.tgz",
-          "integrity": "sha1-xDlc5oOrzSVLwo/h2rtuXCfc/64=",
-          "dev": true,
-          "requires": {
-            "through": "2"
+            "isarray": "0.0.1",
+            "string_decoder": "~0.10.x"
           }
         },
         "string_decoder": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-          "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-          "dev": true,
-          "requires": {
-            "safe-buffer": "~5.1.0"
-          }
+          "version": "0.10.31",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+          "dev": true
         }
       }
     },
     "tap-spec": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/tap-spec/-/tap-spec-5.0.0.tgz",
-      "integrity": "sha512-zMDVJiE5I6Y4XGjlueGXJIX2YIkbDN44broZlnypT38Hj/czfOXrszHNNJBF/DXR8n+x6gbfSx68x04kIEHdrw==",
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/tap-spec/-/tap-spec-2.2.2.tgz",
+      "integrity": "sha1-FK2zmgX5ZMgR73B1lzINO7K7K9o=",
       "dev": true,
       "requires": {
         "chalk": "^1.0.0",
         "duplexer": "^0.1.1",
-        "figures": "^1.4.0",
-        "lodash": "^4.17.10",
-        "pretty-ms": "^2.1.0",
-        "repeat-string": "^1.5.2",
-        "tap-out": "^2.1.0",
-        "through2": "^2.0.0"
+        "pretty-ms": "^1.0.0",
+        "tap-parser": "^0.7.0",
+        "through2": "^0.6.3"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+          "dev": true
+        },
+        "readable-stream": {
+          "version": "1.0.34",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+          "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
+          "dev": true,
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
+            "isarray": "0.0.1",
+            "string_decoder": "~0.10.x"
+          }
+        },
+        "string_decoder": {
+          "version": "0.10.31",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+          "dev": true
+        },
+        "through2": {
+          "version": "0.6.5",
+          "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
+          "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
+          "dev": true,
+          "requires": {
+            "readable-stream": ">=1.0.33-1 <1.1.0-0",
+            "xtend": ">=4.0.0 <4.1.0-0"
+          }
+        }
       }
     },
     "tape": {
@@ -1899,10 +4861,10 @@
         "process": "~0.11.0"
       }
     },
-    "trim": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/trim/-/trim-0.0.1.tgz",
-      "integrity": "sha1-WFhUf2spB1fulczMZm+1AITEYN0=",
+    "trim-newlines": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
+      "integrity": "sha1-WIeWa7WCpFA6QetST301ARgVphM=",
       "dev": true
     },
     "tty-browserify": {
@@ -1997,6 +4959,16 @@
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
       "dev": true
+    },
+    "validate-npm-package-license": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
+      "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
+      "dev": true,
+      "requires": {
+        "spdx-correct": "^3.0.0",
+        "spdx-expression-parse": "^3.0.0"
+      }
     },
     "vm-browserify": {
       "version": "1.1.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openapi-snippet",
-  "version": "0.9.2",
+  "version": "0.9.3",
   "description": "Generates code snippets from Open API (previously Swagger) documents.",
   "repository": {
     "type": "git",
@@ -25,7 +25,8 @@
   },
   "devDependencies": {
     "browserify": "^16.2.3",
-    "tap-spec": "^5.0.0",
+    "prettier": "2.3.0",
+    "tap-spec": "^2.2.2",
     "tape": "^4.10.1",
     "uglifyify": "^5.0.2"
   }

--- a/test/blogger_swagger.json
+++ b/test/blogger_swagger.json
@@ -1,9 +1,6 @@
-
 {
   "swagger": "2.0",
-  "schemes": [
-    "https"
-  ],
+  "schemes": ["https"],
   "host": "www.googleapis.com",
   "basePath": "/blogger/v3",
   "info": {
@@ -48,9 +45,7 @@
     "alt": {
       "default": "json",
       "description": "Data format for the response.",
-      "enum": [
-        "json"
-      ],
+      "enum": ["json"],
       "in": "query",
       "name": "alt",
       "type": "string"
@@ -134,11 +129,7 @@
           },
           {
             "description": "Access level with which to view the blog. Note that some fields require elevated access.",
-            "enum": [
-              "ADMIN",
-              "AUTHOR",
-              "READER"
-            ],
+            "enum": ["ADMIN", "AUTHOR", "READER"],
             "in": "query",
             "name": "view",
             "type": "string"
@@ -154,19 +145,13 @@
         },
         "security": [
           {
-            "Oauth2": [
-              "https://www.googleapis.com/auth/blogger"
-            ]
+            "Oauth2": ["https://www.googleapis.com/auth/blogger"]
           },
           {
-            "Oauth2": [
-              "https://www.googleapis.com/auth/blogger.readonly"
-            ]
+            "Oauth2": ["https://www.googleapis.com/auth/blogger.readonly"]
           }
         ],
-        "tags": [
-          "blogs"
-        ]
+        "tags": ["blogs"]
       },
       "parameters": [
         {
@@ -212,11 +197,7 @@
           },
           {
             "description": "Access level with which to view the blog. Note that some fields require elevated access.",
-            "enum": [
-              "ADMIN",
-              "AUTHOR",
-              "READER"
-            ],
+            "enum": ["ADMIN", "AUTHOR", "READER"],
             "in": "query",
             "name": "view",
             "type": "string"
@@ -232,19 +213,13 @@
         },
         "security": [
           {
-            "Oauth2": [
-              "https://www.googleapis.com/auth/blogger"
-            ]
+            "Oauth2": ["https://www.googleapis.com/auth/blogger"]
           },
           {
-            "Oauth2": [
-              "https://www.googleapis.com/auth/blogger.readonly"
-            ]
+            "Oauth2": ["https://www.googleapis.com/auth/blogger.readonly"]
           }
         ],
-        "tags": [
-          "blogs"
-        ]
+        "tags": ["blogs"]
       },
       "parameters": [
         {
@@ -316,12 +291,7 @@
             "collectionFormat": "multi",
             "in": "query",
             "items": {
-              "enum": [
-                "emptied",
-                "live",
-                "pending",
-                "spam"
-              ],
+              "enum": ["emptied", "live", "pending", "spam"],
               "type": "string"
             },
             "name": "status",
@@ -338,19 +308,13 @@
         },
         "security": [
           {
-            "Oauth2": [
-              "https://www.googleapis.com/auth/blogger"
-            ]
+            "Oauth2": ["https://www.googleapis.com/auth/blogger"]
           },
           {
-            "Oauth2": [
-              "https://www.googleapis.com/auth/blogger.readonly"
-            ]
+            "Oauth2": ["https://www.googleapis.com/auth/blogger.readonly"]
           }
         ],
-        "tags": [
-          "comments"
-        ]
+        "tags": ["comments"]
       },
       "parameters": [
         {
@@ -410,10 +374,7 @@
             "collectionFormat": "multi",
             "in": "query",
             "items": {
-              "enum": [
-                "draft",
-                "live"
-              ],
+              "enum": ["draft", "live"],
               "type": "string"
             },
             "name": "status",
@@ -421,11 +382,7 @@
           },
           {
             "description": "Access level with which to view the returned result. Note that some fields require elevated access.",
-            "enum": [
-              "ADMIN",
-              "AUTHOR",
-              "READER"
-            ],
+            "enum": ["ADMIN", "AUTHOR", "READER"],
             "in": "query",
             "name": "view",
             "type": "string"
@@ -441,19 +398,13 @@
         },
         "security": [
           {
-            "Oauth2": [
-              "https://www.googleapis.com/auth/blogger"
-            ]
+            "Oauth2": ["https://www.googleapis.com/auth/blogger"]
           },
           {
-            "Oauth2": [
-              "https://www.googleapis.com/auth/blogger.readonly"
-            ]
+            "Oauth2": ["https://www.googleapis.com/auth/blogger.readonly"]
           }
         ],
-        "tags": [
-          "pages"
-        ]
+        "tags": ["pages"]
       },
       "parameters": [
         {
@@ -513,14 +464,10 @@
         },
         "security": [
           {
-            "Oauth2": [
-              "https://www.googleapis.com/auth/blogger"
-            ]
+            "Oauth2": ["https://www.googleapis.com/auth/blogger"]
           }
         ],
-        "tags": [
-          "pages"
-        ]
+        "tags": ["pages"]
       }
     },
     "/blogs/{blogId}/pages/{pageId}": {
@@ -550,14 +497,10 @@
         },
         "security": [
           {
-            "Oauth2": [
-              "https://www.googleapis.com/auth/blogger"
-            ]
+            "Oauth2": ["https://www.googleapis.com/auth/blogger"]
           }
         ],
-        "tags": [
-          "pages"
-        ]
+        "tags": ["pages"]
       },
       "get": {
         "description": "Gets one blog page by ID.",
@@ -578,11 +521,7 @@
             "type": "string"
           },
           {
-            "enum": [
-              "ADMIN",
-              "AUTHOR",
-              "READER"
-            ],
+            "enum": ["ADMIN", "AUTHOR", "READER"],
             "in": "query",
             "name": "view",
             "type": "string"
@@ -598,19 +537,13 @@
         },
         "security": [
           {
-            "Oauth2": [
-              "https://www.googleapis.com/auth/blogger"
-            ]
+            "Oauth2": ["https://www.googleapis.com/auth/blogger"]
           },
           {
-            "Oauth2": [
-              "https://www.googleapis.com/auth/blogger.readonly"
-            ]
+            "Oauth2": ["https://www.googleapis.com/auth/blogger.readonly"]
           }
         ],
-        "tags": [
-          "pages"
-        ]
+        "tags": ["pages"]
       },
       "parameters": [
         {
@@ -683,14 +616,10 @@
         },
         "security": [
           {
-            "Oauth2": [
-              "https://www.googleapis.com/auth/blogger"
-            ]
+            "Oauth2": ["https://www.googleapis.com/auth/blogger"]
           }
         ],
-        "tags": [
-          "pages"
-        ]
+        "tags": ["pages"]
       },
       "put": {
         "description": "Update a page.",
@@ -740,14 +669,10 @@
         },
         "security": [
           {
-            "Oauth2": [
-              "https://www.googleapis.com/auth/blogger"
-            ]
+            "Oauth2": ["https://www.googleapis.com/auth/blogger"]
           }
         ],
-        "tags": [
-          "pages"
-        ]
+        "tags": ["pages"]
       }
     },
     "/blogs/{blogId}/pages/{pageId}/publish": {
@@ -803,14 +728,10 @@
         },
         "security": [
           {
-            "Oauth2": [
-              "https://www.googleapis.com/auth/blogger"
-            ]
+            "Oauth2": ["https://www.googleapis.com/auth/blogger"]
           }
         ],
-        "tags": [
-          "pages"
-        ]
+        "tags": ["pages"]
       }
     },
     "/blogs/{blogId}/pages/{pageId}/revert": {
@@ -866,14 +787,10 @@
         },
         "security": [
           {
-            "Oauth2": [
-              "https://www.googleapis.com/auth/blogger"
-            ]
+            "Oauth2": ["https://www.googleapis.com/auth/blogger"]
           }
         ],
-        "tags": [
-          "pages"
-        ]
+        "tags": ["pages"]
       }
     },
     "/blogs/{blogId}/pageviews": {
@@ -892,11 +809,7 @@
             "collectionFormat": "multi",
             "in": "query",
             "items": {
-              "enum": [
-                "30DAYS",
-                "7DAYS",
-                "all"
-              ],
+              "enum": ["30DAYS", "7DAYS", "all"],
               "type": "string"
             },
             "name": "range",
@@ -913,14 +826,10 @@
         },
         "security": [
           {
-            "Oauth2": [
-              "https://www.googleapis.com/auth/blogger"
-            ]
+            "Oauth2": ["https://www.googleapis.com/auth/blogger"]
           }
         ],
-        "tags": [
-          "pageViews"
-        ]
+        "tags": ["pageViews"]
       },
       "parameters": [
         {
@@ -992,10 +901,7 @@
           {
             "default": "published",
             "description": "Sort search results",
-            "enum": [
-              "published",
-              "updated"
-            ],
+            "enum": ["published", "updated"],
             "in": "query",
             "name": "orderBy",
             "type": "string"
@@ -1017,11 +923,7 @@
             "description": "Statuses to include in the results.",
             "in": "query",
             "items": {
-              "enum": [
-                "draft",
-                "live",
-                "scheduled"
-              ],
+              "enum": ["draft", "live", "scheduled"],
               "type": "string"
             },
             "name": "status",
@@ -1029,11 +931,7 @@
           },
           {
             "description": "Access level with which to view the returned result. Note that some fields require escalated access.",
-            "enum": [
-              "ADMIN",
-              "AUTHOR",
-              "READER"
-            ],
+            "enum": ["ADMIN", "AUTHOR", "READER"],
             "in": "query",
             "name": "view",
             "type": "string"
@@ -1049,19 +947,13 @@
         },
         "security": [
           {
-            "Oauth2": [
-              "https://www.googleapis.com/auth/blogger"
-            ]
+            "Oauth2": ["https://www.googleapis.com/auth/blogger"]
           },
           {
-            "Oauth2": [
-              "https://www.googleapis.com/auth/blogger.readonly"
-            ]
+            "Oauth2": ["https://www.googleapis.com/auth/blogger.readonly"]
           }
         ],
-        "tags": [
-          "posts"
-        ]
+        "tags": ["posts"]
       },
       "parameters": [
         {
@@ -1134,14 +1026,10 @@
         },
         "security": [
           {
-            "Oauth2": [
-              "https://www.googleapis.com/auth/blogger"
-            ]
+            "Oauth2": ["https://www.googleapis.com/auth/blogger"]
           }
         ],
-        "tags": [
-          "posts"
-        ]
+        "tags": ["posts"]
       }
     },
     "/blogs/{blogId}/posts/bypath": {
@@ -1171,11 +1059,7 @@
           },
           {
             "description": "Access level with which to view the returned result. Note that some fields require elevated access.",
-            "enum": [
-              "ADMIN",
-              "AUTHOR",
-              "READER"
-            ],
+            "enum": ["ADMIN", "AUTHOR", "READER"],
             "in": "query",
             "name": "view",
             "type": "string"
@@ -1191,19 +1075,13 @@
         },
         "security": [
           {
-            "Oauth2": [
-              "https://www.googleapis.com/auth/blogger"
-            ]
+            "Oauth2": ["https://www.googleapis.com/auth/blogger"]
           },
           {
-            "Oauth2": [
-              "https://www.googleapis.com/auth/blogger.readonly"
-            ]
+            "Oauth2": ["https://www.googleapis.com/auth/blogger.readonly"]
           }
         ],
-        "tags": [
-          "posts"
-        ]
+        "tags": ["posts"]
       },
       "parameters": [
         {
@@ -1258,10 +1136,7 @@
           {
             "default": "published",
             "description": "Sort search results",
-            "enum": [
-              "published",
-              "updated"
-            ],
+            "enum": ["published", "updated"],
             "in": "query",
             "name": "orderBy",
             "type": "string"
@@ -1277,19 +1152,13 @@
         },
         "security": [
           {
-            "Oauth2": [
-              "https://www.googleapis.com/auth/blogger"
-            ]
+            "Oauth2": ["https://www.googleapis.com/auth/blogger"]
           },
           {
-            "Oauth2": [
-              "https://www.googleapis.com/auth/blogger.readonly"
-            ]
+            "Oauth2": ["https://www.googleapis.com/auth/blogger.readonly"]
           }
         ],
-        "tags": [
-          "posts"
-        ]
+        "tags": ["posts"]
       },
       "parameters": [
         {
@@ -1342,14 +1211,10 @@
         },
         "security": [
           {
-            "Oauth2": [
-              "https://www.googleapis.com/auth/blogger"
-            ]
+            "Oauth2": ["https://www.googleapis.com/auth/blogger"]
           }
         ],
-        "tags": [
-          "posts"
-        ]
+        "tags": ["posts"]
       },
       "get": {
         "description": "Get a post by ID.",
@@ -1390,11 +1255,7 @@
           },
           {
             "description": "Access level with which to view the returned result. Note that some fields require elevated access.",
-            "enum": [
-              "ADMIN",
-              "AUTHOR",
-              "READER"
-            ],
+            "enum": ["ADMIN", "AUTHOR", "READER"],
             "in": "query",
             "name": "view",
             "type": "string"
@@ -1410,19 +1271,13 @@
         },
         "security": [
           {
-            "Oauth2": [
-              "https://www.googleapis.com/auth/blogger"
-            ]
+            "Oauth2": ["https://www.googleapis.com/auth/blogger"]
           },
           {
-            "Oauth2": [
-              "https://www.googleapis.com/auth/blogger.readonly"
-            ]
+            "Oauth2": ["https://www.googleapis.com/auth/blogger.readonly"]
           }
         ],
-        "tags": [
-          "posts"
-        ]
+        "tags": ["posts"]
       },
       "parameters": [
         {
@@ -1514,14 +1369,10 @@
         },
         "security": [
           {
-            "Oauth2": [
-              "https://www.googleapis.com/auth/blogger"
-            ]
+            "Oauth2": ["https://www.googleapis.com/auth/blogger"]
           }
         ],
-        "tags": [
-          "posts"
-        ]
+        "tags": ["posts"]
       },
       "put": {
         "description": "Update a post.",
@@ -1590,14 +1441,10 @@
         },
         "security": [
           {
-            "Oauth2": [
-              "https://www.googleapis.com/auth/blogger"
-            ]
+            "Oauth2": ["https://www.googleapis.com/auth/blogger"]
           }
         ],
-        "tags": [
-          "posts"
-        ]
+        "tags": ["posts"]
       }
     },
     "/blogs/{blogId}/posts/{postId}/comments": {
@@ -1653,12 +1500,7 @@
             "collectionFormat": "multi",
             "in": "query",
             "items": {
-              "enum": [
-                "emptied",
-                "live",
-                "pending",
-                "spam"
-              ],
+              "enum": ["emptied", "live", "pending", "spam"],
               "type": "string"
             },
             "name": "status",
@@ -1666,11 +1508,7 @@
           },
           {
             "description": "Access level with which to view the returned result. Note that some fields require elevated access.",
-            "enum": [
-              "ADMIN",
-              "AUTHOR",
-              "READER"
-            ],
+            "enum": ["ADMIN", "AUTHOR", "READER"],
             "in": "query",
             "name": "view",
             "type": "string"
@@ -1686,19 +1524,13 @@
         },
         "security": [
           {
-            "Oauth2": [
-              "https://www.googleapis.com/auth/blogger"
-            ]
+            "Oauth2": ["https://www.googleapis.com/auth/blogger"]
           },
           {
-            "Oauth2": [
-              "https://www.googleapis.com/auth/blogger.readonly"
-            ]
+            "Oauth2": ["https://www.googleapis.com/auth/blogger.readonly"]
           }
         ],
-        "tags": [
-          "comments"
-        ]
+        "tags": ["comments"]
       },
       "parameters": [
         {
@@ -1758,14 +1590,10 @@
         },
         "security": [
           {
-            "Oauth2": [
-              "https://www.googleapis.com/auth/blogger"
-            ]
+            "Oauth2": ["https://www.googleapis.com/auth/blogger"]
           }
         ],
-        "tags": [
-          "comments"
-        ]
+        "tags": ["comments"]
       },
       "get": {
         "description": "Gets one comment by ID.",
@@ -1794,11 +1622,7 @@
           },
           {
             "description": "Access level for the requested comment (default: READER). Note that some comments will require elevated permissions, for example comments where the parent posts which is in a draft state, or comments that are pending moderation.",
-            "enum": [
-              "ADMIN",
-              "AUTHOR",
-              "READER"
-            ],
+            "enum": ["ADMIN", "AUTHOR", "READER"],
             "in": "query",
             "name": "view",
             "type": "string"
@@ -1814,19 +1638,13 @@
         },
         "security": [
           {
-            "Oauth2": [
-              "https://www.googleapis.com/auth/blogger"
-            ]
+            "Oauth2": ["https://www.googleapis.com/auth/blogger"]
           },
           {
-            "Oauth2": [
-              "https://www.googleapis.com/auth/blogger.readonly"
-            ]
+            "Oauth2": ["https://www.googleapis.com/auth/blogger.readonly"]
           }
         ],
-        "tags": [
-          "comments"
-        ]
+        "tags": ["comments"]
       },
       "parameters": [
         {
@@ -1912,14 +1730,10 @@
         },
         "security": [
           {
-            "Oauth2": [
-              "https://www.googleapis.com/auth/blogger"
-            ]
+            "Oauth2": ["https://www.googleapis.com/auth/blogger"]
           }
         ],
-        "tags": [
-          "comments"
-        ]
+        "tags": ["comments"]
       }
     },
     "/blogs/{blogId}/posts/{postId}/comments/{commentId}/removecontent": {
@@ -1982,14 +1796,10 @@
         },
         "security": [
           {
-            "Oauth2": [
-              "https://www.googleapis.com/auth/blogger"
-            ]
+            "Oauth2": ["https://www.googleapis.com/auth/blogger"]
           }
         ],
-        "tags": [
-          "comments"
-        ]
+        "tags": ["comments"]
       }
     },
     "/blogs/{blogId}/posts/{postId}/comments/{commentId}/spam": {
@@ -2052,14 +1862,10 @@
         },
         "security": [
           {
-            "Oauth2": [
-              "https://www.googleapis.com/auth/blogger"
-            ]
+            "Oauth2": ["https://www.googleapis.com/auth/blogger"]
           }
         ],
-        "tags": [
-          "comments"
-        ]
+        "tags": ["comments"]
       }
     },
     "/blogs/{blogId}/posts/{postId}/publish": {
@@ -2121,14 +1927,10 @@
         },
         "security": [
           {
-            "Oauth2": [
-              "https://www.googleapis.com/auth/blogger"
-            ]
+            "Oauth2": ["https://www.googleapis.com/auth/blogger"]
           }
         ],
-        "tags": [
-          "posts"
-        ]
+        "tags": ["posts"]
       }
     },
     "/blogs/{blogId}/posts/{postId}/revert": {
@@ -2184,14 +1986,10 @@
         },
         "security": [
           {
-            "Oauth2": [
-              "https://www.googleapis.com/auth/blogger"
-            ]
+            "Oauth2": ["https://www.googleapis.com/auth/blogger"]
           }
         ],
-        "tags": [
-          "posts"
-        ]
+        "tags": ["posts"]
       }
     },
     "/users/{userId}": {
@@ -2217,19 +2015,13 @@
         },
         "security": [
           {
-            "Oauth2": [
-              "https://www.googleapis.com/auth/blogger"
-            ]
+            "Oauth2": ["https://www.googleapis.com/auth/blogger"]
           },
           {
-            "Oauth2": [
-              "https://www.googleapis.com/auth/blogger.readonly"
-            ]
+            "Oauth2": ["https://www.googleapis.com/auth/blogger.readonly"]
           }
         ],
-        "tags": [
-          "users"
-        ]
+        "tags": ["users"]
       },
       "parameters": [
         {
@@ -2278,11 +2070,7 @@
             "description": "User access types for blogs to include in the results, e.g. AUTHOR will return blogs where the user has author level access. If no roles are specified, defaults to ADMIN and AUTHOR roles.",
             "in": "query",
             "items": {
-              "enum": [
-                "ADMIN",
-                "AUTHOR",
-                "READER"
-              ],
+              "enum": ["ADMIN", "AUTHOR", "READER"],
               "type": "string"
             },
             "name": "role",
@@ -2293,10 +2081,7 @@
             "description": "Blog statuses to include in the result (default: Live blogs only). Note that ADMIN access is required to view deleted blogs.",
             "in": "query",
             "items": {
-              "enum": [
-                "DELETED",
-                "LIVE"
-              ],
+              "enum": ["DELETED", "LIVE"],
               "type": "string"
             },
             "name": "status",
@@ -2304,11 +2089,7 @@
           },
           {
             "description": "Access level with which to view the blogs. Note that some fields require elevated access.",
-            "enum": [
-              "ADMIN",
-              "AUTHOR",
-              "READER"
-            ],
+            "enum": ["ADMIN", "AUTHOR", "READER"],
             "in": "query",
             "name": "view",
             "type": "string"
@@ -2324,19 +2105,13 @@
         },
         "security": [
           {
-            "Oauth2": [
-              "https://www.googleapis.com/auth/blogger"
-            ]
+            "Oauth2": ["https://www.googleapis.com/auth/blogger"]
           },
           {
-            "Oauth2": [
-              "https://www.googleapis.com/auth/blogger.readonly"
-            ]
+            "Oauth2": ["https://www.googleapis.com/auth/blogger.readonly"]
           }
         ],
-        "tags": [
-          "blogs"
-        ]
+        "tags": ["blogs"]
       },
       "parameters": [
         {
@@ -2398,19 +2173,13 @@
         },
         "security": [
           {
-            "Oauth2": [
-              "https://www.googleapis.com/auth/blogger"
-            ]
+            "Oauth2": ["https://www.googleapis.com/auth/blogger"]
           },
           {
-            "Oauth2": [
-              "https://www.googleapis.com/auth/blogger.readonly"
-            ]
+            "Oauth2": ["https://www.googleapis.com/auth/blogger.readonly"]
           }
         ],
-        "tags": [
-          "blogUserInfos"
-        ]
+        "tags": ["blogUserInfos"]
       },
       "parameters": [
         {
@@ -2483,10 +2252,7 @@
           {
             "default": "published",
             "description": "Sort order applied to search results. Default is published.",
-            "enum": [
-              "published",
-              "updated"
-            ],
+            "enum": ["published", "updated"],
             "in": "query",
             "name": "orderBy",
             "type": "string"
@@ -2507,11 +2273,7 @@
             "collectionFormat": "multi",
             "in": "query",
             "items": {
-              "enum": [
-                "draft",
-                "live",
-                "scheduled"
-              ],
+              "enum": ["draft", "live", "scheduled"],
               "type": "string"
             },
             "name": "status",
@@ -2519,11 +2281,7 @@
           },
           {
             "description": "Access level with which to view the returned result. Note that some fields require elevated access.",
-            "enum": [
-              "ADMIN",
-              "AUTHOR",
-              "READER"
-            ],
+            "enum": ["ADMIN", "AUTHOR", "READER"],
             "in": "query",
             "name": "view",
             "type": "string"
@@ -2539,19 +2297,13 @@
         },
         "security": [
           {
-            "Oauth2": [
-              "https://www.googleapis.com/auth/blogger"
-            ]
+            "Oauth2": ["https://www.googleapis.com/auth/blogger"]
           },
           {
-            "Oauth2": [
-              "https://www.googleapis.com/auth/blogger.readonly"
-            ]
+            "Oauth2": ["https://www.googleapis.com/auth/blogger.readonly"]
           }
         ],
-        "tags": [
-          "postUserInfos"
-        ]
+        "tags": ["postUserInfos"]
       },
       "parameters": [
         {
@@ -2620,19 +2372,13 @@
         },
         "security": [
           {
-            "Oauth2": [
-              "https://www.googleapis.com/auth/blogger"
-            ]
+            "Oauth2": ["https://www.googleapis.com/auth/blogger"]
           },
           {
-            "Oauth2": [
-              "https://www.googleapis.com/auth/blogger.readonly"
-            ]
+            "Oauth2": ["https://www.googleapis.com/auth/blogger.readonly"]
           }
         ],
-        "tags": [
-          "postUserInfos"
-        ]
+        "tags": ["postUserInfos"]
       },
       "parameters": [
         {

--- a/test/github_swagger.json
+++ b/test/github_swagger.json
@@ -1,9 +1,6 @@
-
 {
   "swagger": "2.0",
-  "schemes": [
-    "https"
-  ],
+  "schemes": ["https"],
   "host": "api.github.com",
   "basePath": "/",
   "x-hasEquivalentPaths": true,
@@ -27,12 +24,8 @@
   "externalDocs": {
     "url": "https://developer.github.com/v3/"
   },
-  "consumes": [
-    "application/json"
-  ],
-  "produces": [
-    "application/json"
-  ],
+  "consumes": ["application/json"],
+  "produces": ["application/json"],
   "securityDefinitions": {
     "oauth_2_0": {
       "authorizationUrl": "https://github.com/login/oauth/authorize",
@@ -1255,13 +1248,7 @@
           {
             "default": "all",
             "description": "Issues assigned to you / created by you / mentioning you / you're\nsubscribed to updates for / All issues the authenticated user can see\n",
-            "enum": [
-              "assigned",
-              "created",
-              "mentioned",
-              "subscribed",
-              "all"
-            ],
+            "enum": ["assigned", "created", "mentioned", "subscribed", "all"],
             "in": "query",
             "name": "filter",
             "required": true,
@@ -1269,10 +1256,7 @@
           },
           {
             "default": "open",
-            "enum": [
-              "open",
-              "closed"
-            ],
+            "enum": ["open", "closed"],
             "in": "query",
             "name": "state",
             "required": true,
@@ -1287,11 +1271,7 @@
           },
           {
             "default": "created",
-            "enum": [
-              "created",
-              "updated",
-              "comments"
-            ],
+            "enum": ["created", "updated", "comments"],
             "in": "query",
             "name": "sort",
             "required": true,
@@ -1299,10 +1279,7 @@
           },
           {
             "default": "desc",
-            "enum": [
-              "asc",
-              "desc"
-            ],
+            "enum": ["asc", "desc"],
             "in": "query",
             "name": "direction",
             "required": true,
@@ -1373,10 +1350,7 @@
           },
           {
             "description": "Indicates the state of the issues to return. Can be either open or closed.",
-            "enum": [
-              "open",
-              "closed"
-            ],
+            "enum": ["open", "closed"],
             "in": "path",
             "name": "state",
             "required": true,
@@ -1454,10 +1428,7 @@
           {
             "default": "desc",
             "description": "The sort field. if sort param is provided. Can be either asc or desc.",
-            "enum": [
-              "desc",
-              "asc"
-            ],
+            "enum": ["desc", "asc"],
             "in": "query",
             "name": "order",
             "type": "string"
@@ -1476,11 +1447,7 @@
           },
           {
             "description": "The sort field. One of stars, forks, or updated. Default: results are sorted by best match.",
-            "enum": [
-              "updated",
-              "stars",
-              "forks"
-            ],
+            "enum": ["updated", "stars", "forks"],
             "in": "query",
             "name": "sort",
             "type": "string"
@@ -1602,10 +1569,7 @@
           {
             "default": "desc",
             "description": "The sort field. if sort param is provided. Can be either asc or desc.",
-            "enum": [
-              "desc",
-              "asc"
-            ],
+            "enum": ["desc", "asc"],
             "in": "query",
             "name": "order",
             "type": "string"
@@ -1618,11 +1582,7 @@
           },
           {
             "description": "The sort field. One of stars, forks, or updated. Default: results are sorted by best match.",
-            "enum": [
-              "updated",
-              "stars",
-              "forks"
-            ],
+            "enum": ["updated", "stars", "forks"],
             "in": "query",
             "name": "sort",
             "type": "string"
@@ -1718,9 +1678,7 @@
             }
           }
         ],
-        "produces": [
-          "text/html"
-        ],
+        "produces": ["text/html"],
         "responses": {
           "200": {
             "description": "OK"
@@ -1733,9 +1691,7 @@
     },
     "/markdown/raw": {
       "post": {
-        "consumes": [
-          "text/plain"
-        ],
+        "consumes": ["text/plain"],
         "description": "Render a Markdown document in raw mode",
         "parameters": [
           {
@@ -1771,9 +1727,7 @@
             "type": "integer"
           }
         ],
-        "produces": [
-          "text/html"
-        ],
+        "produces": ["text/html"],
         "responses": {
           "200": {
             "description": "OK"
@@ -2491,13 +2445,7 @@
           {
             "default": "all",
             "description": "Issues assigned to you / created by you / mentioning you / you're\nsubscribed to updates for / All issues the authenticated user can see\n",
-            "enum": [
-              "assigned",
-              "created",
-              "mentioned",
-              "subscribed",
-              "all"
-            ],
+            "enum": ["assigned", "created", "mentioned", "subscribed", "all"],
             "in": "query",
             "name": "filter",
             "required": true,
@@ -2505,10 +2453,7 @@
           },
           {
             "default": "open",
-            "enum": [
-              "open",
-              "closed"
-            ],
+            "enum": ["open", "closed"],
             "in": "query",
             "name": "state",
             "required": true,
@@ -2523,11 +2468,7 @@
           },
           {
             "default": "created",
-            "enum": [
-              "created",
-              "updated",
-              "comments"
-            ],
+            "enum": ["created", "updated", "comments"],
             "in": "query",
             "name": "sort",
             "required": true,
@@ -2535,10 +2476,7 @@
           },
           {
             "default": "desc",
-            "enum": [
-              "asc",
-              "desc"
-            ],
+            "enum": ["asc", "desc"],
             "in": "query",
             "name": "direction",
             "required": true,
@@ -3034,14 +2972,7 @@
           },
           {
             "default": "all",
-            "enum": [
-              "all",
-              "public",
-              "private",
-              "forks",
-              "sources",
-              "member"
-            ],
+            "enum": ["all", "public", "private", "forks", "sources", "member"],
             "in": "query",
             "name": "type",
             "type": "string"
@@ -5661,11 +5592,7 @@
           },
           {
             "default": "newes",
-            "enum": [
-              "newes",
-              "oldes",
-              "watchers"
-            ],
+            "enum": ["newes", "oldes", "watchers"],
             "in": "query",
             "name": "sort",
             "type": "string"
@@ -7145,13 +7072,7 @@
           {
             "default": "all",
             "description": "Issues assigned to you / created by you / mentioning you / you're\nsubscribed to updates for / All issues the authenticated user can see\n",
-            "enum": [
-              "assigned",
-              "created",
-              "mentioned",
-              "subscribed",
-              "all"
-            ],
+            "enum": ["assigned", "created", "mentioned", "subscribed", "all"],
             "in": "query",
             "name": "filter",
             "required": true,
@@ -7159,10 +7080,7 @@
           },
           {
             "default": "open",
-            "enum": [
-              "open",
-              "closed"
-            ],
+            "enum": ["open", "closed"],
             "in": "query",
             "name": "state",
             "required": true,
@@ -7177,11 +7095,7 @@
           },
           {
             "default": "created",
-            "enum": [
-              "created",
-              "updated",
-              "comments"
-            ],
+            "enum": ["created", "updated", "comments"],
             "in": "query",
             "name": "sort",
             "required": true,
@@ -7189,10 +7103,7 @@
           },
           {
             "default": "desc",
-            "enum": [
-              "asc",
-              "desc"
-            ],
+            "enum": ["asc", "desc"],
             "in": "query",
             "name": "direction",
             "required": true,
@@ -7346,10 +7257,7 @@
           },
           {
             "description": "",
-            "enum": [
-              "created",
-              "updated"
-            ],
+            "enum": ["created", "updated"],
             "in": "query",
             "name": "sort",
             "type": "string"
@@ -9279,10 +9187,7 @@
           {
             "default": "open",
             "description": "String to filter by state.",
-            "enum": [
-              "open",
-              "closed"
-            ],
+            "enum": ["open", "closed"],
             "in": "query",
             "name": "state",
             "type": "string"
@@ -9296,10 +9201,7 @@
           {
             "default": "due_date",
             "description": "",
-            "enum": [
-              "due_date",
-              "completeness"
-            ],
+            "enum": ["due_date", "completeness"],
             "in": "query",
             "name": "sort",
             "type": "string"
@@ -9875,10 +9777,7 @@
           {
             "default": "open",
             "description": "String to filter by state.",
-            "enum": [
-              "open",
-              "closed"
-            ],
+            "enum": ["open", "closed"],
             "in": "query",
             "name": "state",
             "type": "string"
@@ -10037,10 +9936,7 @@
           },
           {
             "description": "",
-            "enum": [
-              "created",
-              "updated"
-            ],
+            "enum": ["created", "updated"],
             "in": "query",
             "name": "sort",
             "type": "string"
@@ -12599,10 +12495,7 @@
             "type": "string"
           },
           {
-            "enum": [
-              "tarball",
-              "zipball"
-            ],
+            "enum": ["tarball", "zipball"],
             "in": "path",
             "name": "archive_format",
             "required": true,
@@ -12721,10 +12614,7 @@
           {
             "default": "desc",
             "description": "The sort field. if sort param is provided. Can be either asc or desc.",
-            "enum": [
-              "desc",
-              "asc"
-            ],
+            "enum": ["desc", "asc"],
             "in": "query",
             "name": "order",
             "type": "string"
@@ -12738,9 +12628,7 @@
           },
           {
             "description": "Can only be 'indexed', which indicates how recently a file has been indexed\nby the GitHub search infrastructure. If not provided, results are sorted\nby best match.\n",
-            "enum": [
-              "indexed"
-            ],
+            "enum": ["indexed"],
             "in": "query",
             "name": "sort",
             "type": "string"
@@ -12798,10 +12686,7 @@
           {
             "default": "desc",
             "description": "The sort field. if sort param is provided. Can be either asc or desc.",
-            "enum": [
-              "desc",
-              "asc"
-            ],
+            "enum": ["desc", "asc"],
             "in": "query",
             "name": "order",
             "type": "string"
@@ -12815,11 +12700,7 @@
           },
           {
             "description": "The sort field. Can be comments, created, or updated. Default: results are sorted by best match.",
-            "enum": [
-              "updated",
-              "created",
-              "comments"
-            ],
+            "enum": ["updated", "created", "comments"],
             "in": "query",
             "name": "sort",
             "type": "string"
@@ -12877,10 +12758,7 @@
           {
             "default": "desc",
             "description": "The sort field. if sort param is provided. Can be either asc or desc.",
-            "enum": [
-              "desc",
-              "asc"
-            ],
+            "enum": ["desc", "asc"],
             "in": "query",
             "name": "order",
             "type": "string"
@@ -12894,11 +12772,7 @@
           },
           {
             "description": "If not provided, results are sorted by best match.",
-            "enum": [
-              "stars",
-              "forks",
-              "updated"
-            ],
+            "enum": ["stars", "forks", "updated"],
             "in": "query",
             "name": "sort",
             "type": "string"
@@ -12956,10 +12830,7 @@
           {
             "default": "desc",
             "description": "The sort field. if sort param is provided. Can be either asc or desc.",
-            "enum": [
-              "desc",
-              "asc"
-            ],
+            "enum": ["desc", "asc"],
             "in": "query",
             "name": "order",
             "type": "string"
@@ -12973,11 +12844,7 @@
           },
           {
             "description": "If not provided, results are sorted by best match.",
-            "enum": [
-              "followers",
-              "repositories",
-              "joined"
-            ],
+            "enum": ["followers", "repositories", "joined"],
             "in": "query",
             "name": "sort",
             "type": "string"
@@ -14088,9 +13955,7 @@
             "type": "integer"
           }
         ],
-        "produces": [
-          "application/vnd.github.v3"
-        ],
+        "produces": ["application/vnd.github.v3"],
         "responses": {
           "200": {
             "description": "OK",
@@ -14422,13 +14287,7 @@
           {
             "default": "all",
             "description": "Issues assigned to you / created by you / mentioning you / you're\nsubscribed to updates for / All issues the authenticated user can see\n",
-            "enum": [
-              "assigned",
-              "created",
-              "mentioned",
-              "subscribed",
-              "all"
-            ],
+            "enum": ["assigned", "created", "mentioned", "subscribed", "all"],
             "in": "query",
             "name": "filter",
             "required": true,
@@ -14436,10 +14295,7 @@
           },
           {
             "default": "open",
-            "enum": [
-              "open",
-              "closed"
-            ],
+            "enum": ["open", "closed"],
             "in": "query",
             "name": "state",
             "required": true,
@@ -14454,11 +14310,7 @@
           },
           {
             "default": "created",
-            "enum": [
-              "created",
-              "updated",
-              "comments"
-            ],
+            "enum": ["created", "updated", "comments"],
             "in": "query",
             "name": "sort",
             "required": true,
@@ -14466,10 +14318,7 @@
           },
           {
             "default": "desc",
-            "enum": [
-              "asc",
-              "desc"
-            ],
+            "enum": ["asc", "desc"],
             "in": "query",
             "name": "direction",
             "required": true,
@@ -14798,14 +14647,7 @@
         "parameters": [
           {
             "default": "all",
-            "enum": [
-              "all",
-              "public",
-              "private",
-              "forks",
-              "sources",
-              "member"
-            ],
+            "enum": ["all", "public", "private", "forks", "sources", "member"],
             "in": "query",
             "name": "type",
             "type": "string"
@@ -14925,10 +14767,7 @@
           {
             "default": "created",
             "description": "",
-            "enum": [
-              "created",
-              "updated"
-            ],
+            "enum": ["created", "updated"],
             "in": "query",
             "name": "sort",
             "type": "string"
@@ -16077,14 +15916,7 @@
           },
           {
             "default": "all",
-            "enum": [
-              "all",
-              "public",
-              "private",
-              "forks",
-              "sources",
-              "member"
-            ],
+            "enum": ["all", "public", "private", "forks", "sources", "member"],
             "in": "query",
             "name": "type",
             "type": "string"
@@ -16339,9 +16171,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "name"
-      ],
+      "required": ["name"],
       "type": "object"
     },
     "assets": {
@@ -16467,10 +16297,7 @@
           "type": "string"
         },
         "encoding": {
-          "enum": [
-            "utf-8",
-            "base64"
-          ]
+          "enum": ["utf-8", "base64"]
         },
         "sha": {
           "type": "string"
@@ -16689,9 +16516,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "body"
-      ],
+      "required": ["body"],
       "type": "object"
     },
     "comments": {
@@ -16944,10 +16769,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "sha",
-        "body"
-      ],
+      "required": ["sha", "body"],
       "type": "object"
     },
     "commitComments": {
@@ -18238,10 +18060,7 @@
           "type": "integer"
         }
       },
-      "required": [
-        "name",
-        "size"
-      ],
+      "required": ["name", "size"],
       "type": "object"
     },
     "downloads": {
@@ -18279,16 +18098,10 @@
           "type": "string"
         },
         "permission": {
-          "enum": [
-            "pull",
-            "push",
-            "admin"
-          ]
+          "enum": ["pull", "push", "admin"]
         }
       },
-      "required": [
-        "name"
-      ],
+      "required": ["name"],
       "type": "object"
     },
     "emailsPost": {
@@ -18453,10 +18266,7 @@
                   "type": "integer"
                 },
                 "state": {
-                  "enum": [
-                    "open",
-                    "closed"
-                  ]
+                  "enum": ["open", "closed"]
                 },
                 "title": {
                   "type": "string"
@@ -18485,10 +18295,7 @@
               "type": "object"
             },
             "state": {
-              "enum": [
-                "open",
-                "closed"
-              ]
+              "enum": ["open", "closed"]
             },
             "title": {
               "type": "string"
@@ -19249,10 +19056,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "sha",
-        "force"
-      ],
+      "required": ["sha", "force"],
       "type": "object"
     },
     "heads": {
@@ -19504,10 +19308,7 @@
                 "type": "integer"
               },
               "state": {
-                "enum": [
-                  "open",
-                  "closed"
-                ]
+                "enum": ["open", "closed"]
               },
               "title": {
                 "type": "string"
@@ -19536,10 +19337,7 @@
             "type": "object"
           },
           "state": {
-            "enum": [
-              "open",
-              "closed"
-            ]
+            "enum": ["open", "closed"]
           },
           "title": {
             "type": "string"
@@ -20136,10 +19934,7 @@
           "type": "integer"
         },
         "state": {
-          "enum": [
-            "open",
-            "closed"
-          ]
+          "enum": ["open", "closed"]
         },
         "title": {
           "type": "string"
@@ -20350,11 +20145,7 @@
           "type": "string"
         },
         "permission": {
-          "enum": [
-            "pull",
-            "push",
-            "admin"
-          ]
+          "enum": ["pull", "push", "admin"]
         },
         "repo_names": {
           "items": {
@@ -20363,9 +20154,7 @@
           "type": "array"
         }
       },
-      "required": [
-        "name"
-      ],
+      "required": ["name"],
       "type": "object"
     },
     "organization": {
@@ -20534,9 +20323,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "body"
-      ],
+      "required": ["body"],
       "type": "object"
     },
     "postGist": {
@@ -20603,9 +20390,7 @@
           "type": "integer"
         }
       },
-      "required": [
-        "name"
-      ],
+      "required": ["name"],
       "type": "object"
     },
     "pullRequest": {
@@ -21392,10 +21177,7 @@
             "type": "string"
           },
           "state": {
-            "enum": [
-              "open",
-              "closed"
-            ]
+            "enum": ["open", "closed"]
           },
           "title": {
             "type": "string"
@@ -22919,11 +22701,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "message",
-        "parents",
-        "tree"
-      ],
+      "required": ["message", "parents", "tree"],
       "type": "object"
     },
     "repoEdit": {
@@ -24068,13 +23846,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "tag",
-        "message",
-        "object",
-        "type",
-        "tagger"
-      ],
+      "required": ["tag", "message", "object", "type", "tagger"],
       "type": "object"
     },
     "team": {
@@ -24328,13 +24100,7 @@
             "properties": {
               "mode": {
                 "description": "One of 100644 for file (blob), 100755 for executable (blob), 040000 for subdirectory (tree), 160000 for submodule (commit) or 120000 for a blob that specifies the path of a symlink.",
-                "enum": [
-                  "100644",
-                  "100755",
-                  "040000",
-                  "160000",
-                  "120000"
-                ],
+                "enum": ["100644", "100755", "040000", "160000", "120000"],
                 "type": "string"
               },
               "path": {
@@ -24345,11 +24111,7 @@
                 "type": "string"
               },
               "type": {
-                "enum": [
-                  "blob",
-                  "tree",
-                  "commit"
-                ],
+                "enum": ["blob", "tree", "commit"],
                 "type": "string"
               },
               "url": {

--- a/test/ibm_watson_alchemy_data_news_api.json
+++ b/test/ibm_watson_alchemy_data_news_api.json
@@ -1,1 +1,953 @@
-{"swagger":"2.0","info":{"title":"IBM Alchemy Data News","version":"1.0","description":"Alchemy Data News provides news and blog content enriched with natural language processing to allow for highly targeted search and trend analysis. Now you can query the world's news sources and blogs like a database.","x-tags":["News","Natural Language Processing","Blogs"],"contact":{"url":"https://support.ng.bluemix.net/supportticket/"}},"externalDocs":{"url":"https://www.ibm.com/watson/developercloud/alchemydata-news/api/v1/"},"host":"gateway-a.watsonplatform.net","schemes":["https"],"basePath":"/calls","paths":{"/data/GetNews":{"get":{"tags":["News"],"summary":"Analyze news","description":"Analyze news using Natural Language Processing (NLP) queries and sophisticated filters.","operationId":"GetNews","produces":["application/json","application/xml"],"parameters":[{"in":"query","description":"API key (optional in the API explorer)","name":"apikey","required":true,"type":"string"},{"in":"query","description":"Output mode","name":"outputMode","type":"string","enum":["xml","json"],"default":"json"},{"in":"query","description":"Start date","name":"start","required":true,"type":"string","default":"now-1d"},{"in":"query","description":"End date","name":"end","required":true,"type":"string","default":"now"},{"in":"query","description":"Maximum results","name":"maxResults","default":10,"type":"integer"},{"in":"query","description":"Time slice","name":"timeSlice","type":"string"},{"in":"query","description":"Fields to return for each document (comma separated). e.g. enriched.url.title,enriched.url.author,enriched.url.keywords","name":"return","type":"string","collectionFormat":"csv"},{"in":"query","description":"Example filter query parameter (title relations)","name":"q.enriched.url.enrichedTitle.relations.relation","type":"string"},{"in":"query","description":"Example filter query parameter (title entity)","name":"q.enriched.url.enrichedTitle.entities.entity","type":"string"},{"in":"query","description":"Example filter query parameter (title taxonomy)","name":"q.enriched.url.enrichedTitle.taxonomy.taxonomy_","type":"string"},{"in":"query","description":"Example filter query parameter (sentiment)","name":"q.enriched.url.enrichedTitle.docSentiment.type","type":"string"}],"responses":{"200":{"description":"OK","schema":{"$ref":"#/definitions/NewsResponse"}}},"x-apih-advice":{"totalUsageCount":26,"topQueryParams":[{"paramName":"apikey","paramValues":[{"value":"<Hiding desensitized value>","count":3,"source":["https://github.com/cmoulika009/ASE-Lab-Assignments/blob/9e0731d8dde2fd5b7b3145ce25e7d598f8903903/Lab-3-Mashup%20Application/Source/js/app.js#L222","https://github.com/cmoulika009/ASE-Lab-Assignments/blob/324ade52edd760d697ed597936265781412285f3/Lab-9-Cloud-Based-App-II/Source/Cloud%20App/js/app.js#L222","https://github.com/ljm7b2/advSftwrEngnrTest/blob/dedd1afd4f0ddd52b9d1b94f8dce2cb0d5533de7/Source/LAB_5_MASHUP_SOURCE_CODE/lab_5_API_alchemyNEWS_SPOTIFY_playlists/app.js#L221"]},{"value":"<Hiding desensitized value>","count":2,"source":["https://github.com/sickle5stone/FishyBusiness/blob/230dd18dfdb1a167c3ab39390fc87374dd67d9c0/js/news.js#L64","https://github.com/kongyujian/Fishackathon2016_Geospatial/blob/3eba2dd89c82761b7b11d32dc3b5817727ec7d27/js/news.js#L64"]},{"value":"<Hiding desensitized value>","count":2,"source":["https://github.com/FlyMoe/Candidus-Informatio/blob/4ecbac214df76e1493cfffc11ba45321a7543b30/assets/javascript/app.js#L414","https://github.com/alexlcortes/another-test-repo/blob/c216a20deeec16d648256197df6bd2033131ffde/assets/javascript/app.js#L414"]},{"value":"<Hiding desensitized value>","count":2,"source":["https://github.com/wjohnson1000/Frontend_Personal_Project/blob/fd1244fae8a9932819ed287c6f53611b1acd6158/source/scripts/main.js#L52","https://github.com/wjohnson1000/wjohnson1000.github.io/blob/cb99bea35ebb38d6a246fd1da701d83550d769a5/scripts/main.js#L56"]}],"bestSources":null,"count":10},{"paramName":"end","paramValues":[{"value":"now","count":10,"source":["https://github.com/sickle5stone/FishyBusiness/blob/230dd18dfdb1a167c3ab39390fc87374dd67d9c0/js/news.js#L64","https://github.com/wjohnson1000/Frontend_Personal_Project/blob/fd1244fae8a9932819ed287c6f53611b1acd6158/source/scripts/main.js#L52","https://github.com/alexbtk/amos-ss16-proj9/blob/d667a46692f0ea440696a60d6212582f1352006d/src/main/webapp/js/AMOSAlchemy.js#L26","https://github.com/cmoulika009/ASE-Lab-Assignments/blob/9e0731d8dde2fd5b7b3145ce25e7d598f8903903/Lab-3-Mashup%20Application/Source/js/app.js#L222","https://github.com/kongyujian/Fishackathon2016_Geospatial/blob/3eba2dd89c82761b7b11d32dc3b5817727ec7d27/js/news.js#L64","https://github.com/wjohnson1000/wjohnson1000.github.io/blob/cb99bea35ebb38d6a246fd1da701d83550d769a5/scripts/main.js#L56","https://github.com/cmoulika009/ASE-Lab-Assignments/blob/324ade52edd760d697ed597936265781412285f3/Lab-9-Cloud-Based-App-II/Source/Cloud%20App/js/app.js#L222","https://github.com/ljm7b2/advSftwrEngnrTest/blob/dedd1afd4f0ddd52b9d1b94f8dce2cb0d5533de7/Source/LAB_5_MASHUP_SOURCE_CODE/lab_5_API_alchemyNEWS_SPOTIFY_playlists/app.js#L221","https://github.com/FlyMoe/Candidus-Informatio/blob/4ecbac214df76e1493cfffc11ba45321a7543b30/assets/javascript/app.js#L414","https://github.com/alexlcortes/another-test-repo/blob/c216a20deeec16d648256197df6bd2033131ffde/assets/javascript/app.js#L414"]}],"bestSources":[{"url":"https://github.com/FlyMoe/Candidus-Informatio/blob/4ecbac214df76e1493cfffc11ba45321a7543b30/assets/javascript/app.js#L414","sourceId":2},{"url":"https://github.com/alexlcortes/another-test-repo/blob/c216a20deeec16d648256197df6bd2033131ffde/assets/javascript/app.js#L414","sourceId":3}],"count":10},{"paramName":"outputMode","paramValues":[{"value":"json","count":10,"source":["https://github.com/sickle5stone/FishyBusiness/blob/230dd18dfdb1a167c3ab39390fc87374dd67d9c0/js/news.js#L64","https://github.com/wjohnson1000/Frontend_Personal_Project/blob/fd1244fae8a9932819ed287c6f53611b1acd6158/source/scripts/main.js#L52","https://github.com/alexbtk/amos-ss16-proj9/blob/d667a46692f0ea440696a60d6212582f1352006d/src/main/webapp/js/AMOSAlchemy.js#L26","https://github.com/cmoulika009/ASE-Lab-Assignments/blob/9e0731d8dde2fd5b7b3145ce25e7d598f8903903/Lab-3-Mashup%20Application/Source/js/app.js#L222","https://github.com/kongyujian/Fishackathon2016_Geospatial/blob/3eba2dd89c82761b7b11d32dc3b5817727ec7d27/js/news.js#L64","https://github.com/wjohnson1000/wjohnson1000.github.io/blob/cb99bea35ebb38d6a246fd1da701d83550d769a5/scripts/main.js#L56","https://github.com/cmoulika009/ASE-Lab-Assignments/blob/324ade52edd760d697ed597936265781412285f3/Lab-9-Cloud-Based-App-II/Source/Cloud%20App/js/app.js#L222","https://github.com/ljm7b2/advSftwrEngnrTest/blob/dedd1afd4f0ddd52b9d1b94f8dce2cb0d5533de7/Source/LAB_5_MASHUP_SOURCE_CODE/lab_5_API_alchemyNEWS_SPOTIFY_playlists/app.js#L221","https://github.com/FlyMoe/Candidus-Informatio/blob/4ecbac214df76e1493cfffc11ba45321a7543b30/assets/javascript/app.js#L414","https://github.com/alexlcortes/another-test-repo/blob/c216a20deeec16d648256197df6bd2033131ffde/assets/javascript/app.js#L414"]}],"bestSources":[{"url":"https://github.com/FlyMoe/Candidus-Informatio/blob/4ecbac214df76e1493cfffc11ba45321a7543b30/assets/javascript/app.js#L414","sourceId":2},{"url":"https://github.com/alexlcortes/another-test-repo/blob/c216a20deeec16d648256197df6bd2033131ffde/assets/javascript/app.js#L414","sourceId":3}],"count":10},{"paramName":"return","paramValues":[{"value":"enriched.url.url,enriched.url.title","count":7,"source":["https://github.com/wjohnson1000/Frontend_Personal_Project/blob/fd1244fae8a9932819ed287c6f53611b1acd6158/source/scripts/main.js#L52","https://github.com/cmoulika009/ASE-Lab-Assignments/blob/9e0731d8dde2fd5b7b3145ce25e7d598f8903903/Lab-3-Mashup%20Application/Source/js/app.js#L222","https://github.com/wjohnson1000/wjohnson1000.github.io/blob/cb99bea35ebb38d6a246fd1da701d83550d769a5/scripts/main.js#L56","https://github.com/cmoulika009/ASE-Lab-Assignments/blob/324ade52edd760d697ed597936265781412285f3/Lab-9-Cloud-Based-App-II/Source/Cloud%20App/js/app.js#L222","https://github.com/ljm7b2/advSftwrEngnrTest/blob/dedd1afd4f0ddd52b9d1b94f8dce2cb0d5533de7/Source/LAB_5_MASHUP_SOURCE_CODE/lab_5_API_alchemyNEWS_SPOTIFY_playlists/app.js#L221","https://github.com/FlyMoe/Candidus-Informatio/blob/4ecbac214df76e1493cfffc11ba45321a7543b30/assets/javascript/app.js#L414","https://github.com/alexlcortes/another-test-repo/blob/c216a20deeec16d648256197df6bd2033131ffde/assets/javascript/app.js#L414"]},{"value":"enriched.url.url,enriched.url.title,enriched.url.text","count":2,"source":["https://github.com/sickle5stone/FishyBusiness/blob/230dd18dfdb1a167c3ab39390fc87374dd67d9c0/js/news.js#L64","https://github.com/kongyujian/Fishackathon2016_Geospatial/blob/3eba2dd89c82761b7b11d32dc3b5817727ec7d27/js/news.js#L64"]},{"value":"q.enriched.url.title,q.enriched.url.entities","count":1,"source":["https://github.com/alexbtk/amos-ss16-proj9/blob/d667a46692f0ea440696a60d6212582f1352006d/src/main/webapp/js/AMOSAlchemy.js#L26"]}],"bestSources":null,"count":10},{"paramName":"start","paramValues":[{"value":"now-1d","count":5,"source":["https://github.com/wjohnson1000/Frontend_Personal_Project/blob/fd1244fae8a9932819ed287c6f53611b1acd6158/source/scripts/main.js#L52","https://github.com/cmoulika009/ASE-Lab-Assignments/blob/9e0731d8dde2fd5b7b3145ce25e7d598f8903903/Lab-3-Mashup%20Application/Source/js/app.js#L222","https://github.com/wjohnson1000/wjohnson1000.github.io/blob/cb99bea35ebb38d6a246fd1da701d83550d769a5/scripts/main.js#L56","https://github.com/cmoulika009/ASE-Lab-Assignments/blob/324ade52edd760d697ed597936265781412285f3/Lab-9-Cloud-Based-App-II/Source/Cloud%20App/js/app.js#L222","https://github.com/ljm7b2/advSftwrEngnrTest/blob/dedd1afd4f0ddd52b9d1b94f8dce2cb0d5533de7/Source/LAB_5_MASHUP_SOURCE_CODE/lab_5_API_alchemyNEWS_SPOTIFY_playlists/app.js#L221"]},{"value":"now-3.0d","count":2,"source":["https://github.com/FlyMoe/Candidus-Informatio/blob/4ecbac214df76e1493cfffc11ba45321a7543b30/assets/javascript/app.js#L414","https://github.com/alexlcortes/another-test-repo/blob/c216a20deeec16d648256197df6bd2033131ffde/assets/javascript/app.js#L414"]},{"value":"now-7d","count":2,"source":["https://github.com/sickle5stone/FishyBusiness/blob/230dd18dfdb1a167c3ab39390fc87374dd67d9c0/js/news.js#L64","https://github.com/kongyujian/Fishackathon2016_Geospatial/blob/3eba2dd89c82761b7b11d32dc3b5817727ec7d27/js/news.js#L64"]},{"value":"now-3d","count":1,"source":["https://github.com/alexbtk/amos-ss16-proj9/blob/d667a46692f0ea440696a60d6212582f1352006d/src/main/webapp/js/AMOSAlchemy.js#L26"]}],"bestSources":null,"count":10},{"paramName":"count","paramValues":[{"value":"5","count":9,"source":["https://github.com/sickle5stone/FishyBusiness/blob/230dd18dfdb1a167c3ab39390fc87374dd67d9c0/js/news.js#L64","https://github.com/wjohnson1000/Frontend_Personal_Project/blob/fd1244fae8a9932819ed287c6f53611b1acd6158/source/scripts/main.js#L52","https://github.com/cmoulika009/ASE-Lab-Assignments/blob/9e0731d8dde2fd5b7b3145ce25e7d598f8903903/Lab-3-Mashup%20Application/Source/js/app.js#L222","https://github.com/kongyujian/Fishackathon2016_Geospatial/blob/3eba2dd89c82761b7b11d32dc3b5817727ec7d27/js/news.js#L64","https://github.com/wjohnson1000/wjohnson1000.github.io/blob/cb99bea35ebb38d6a246fd1da701d83550d769a5/scripts/main.js#L56","https://github.com/cmoulika009/ASE-Lab-Assignments/blob/324ade52edd760d697ed597936265781412285f3/Lab-9-Cloud-Based-App-II/Source/Cloud%20App/js/app.js#L222","https://github.com/ljm7b2/advSftwrEngnrTest/blob/dedd1afd4f0ddd52b9d1b94f8dce2cb0d5533de7/Source/LAB_5_MASHUP_SOURCE_CODE/lab_5_API_alchemyNEWS_SPOTIFY_playlists/app.js#L221","https://github.com/FlyMoe/Candidus-Informatio/blob/4ecbac214df76e1493cfffc11ba45321a7543b30/assets/javascript/app.js#L414","https://github.com/alexlcortes/another-test-repo/blob/c216a20deeec16d648256197df6bd2033131ffde/assets/javascript/app.js#L414"]}],"bestSources":[{"url":"https://github.com/FlyMoe/Candidus-Informatio/blob/4ecbac214df76e1493cfffc11ba45321a7543b30/assets/javascript/app.js#L414","sourceId":2},{"url":"https://github.com/alexlcortes/another-test-repo/blob/c216a20deeec16d648256197df6bd2033131ffde/assets/javascript/app.js#L414","sourceId":3}],"count":9},{"paramName":"q.enriched.url.enrichedTitle.keywords.keyword.text","paramValues":[{"value":"{candidateNameArray.0 candidateNameArray.1}","count":2,"source":["https://github.com/FlyMoe/Candidus-Informatio/blob/4ecbac214df76e1493cfffc11ba45321a7543b30/assets/javascript/app.js#L414","https://github.com/alexlcortes/another-test-repo/blob/c216a20deeec16d648256197df6bd2033131ffde/assets/javascript/app.js#L414"]},{"value":"{newsTopic}","count":2,"source":["https://github.com/wjohnson1000/Frontend_Personal_Project/blob/fd1244fae8a9932819ed287c6f53611b1acd6158/source/scripts/main.js#L52","https://github.com/wjohnson1000/wjohnson1000.github.io/blob/cb99bea35ebb38d6a246fd1da701d83550d769a5/scripts/main.js#L56"]}],"bestSources":null,"count":7},{"paramName":"q.enriched.url.title","paramValues":[{"value":"Asian Carp","count":2,"source":["https://github.com/sickle5stone/FishyBusiness/blob/230dd18dfdb1a167c3ab39390fc87374dd67d9c0/js/news.js#L64","https://github.com/kongyujian/Fishackathon2016_Geospatial/blob/3eba2dd89c82761b7b11d32dc3b5817727ec7d27/js/news.js#L64"]}],"bestSources":null,"count":2}],"topPayloadParams":[{"paramName":"end","paramValues":[{"value":"now","count":1,"source":["https://github.com/sfaries/AlchemyNews/blob/891a9ef358cc76e03d521d1569d5708134171732/js/alchemy.js#L47"]}],"bestSources":[{"url":"https://github.com/sfaries/AlchemyNews/blob/891a9ef358cc76e03d521d1569d5708134171732/js/alchemy.js#L47","sourceId":1}],"count":1},{"paramName":"maxResults","paramValues":[{"value":"10","count":1,"source":["https://github.com/sfaries/AlchemyNews/blob/891a9ef358cc76e03d521d1569d5708134171732/js/alchemy.js#L47"]}],"bestSources":[{"url":"https://github.com/sfaries/AlchemyNews/blob/891a9ef358cc76e03d521d1569d5708134171732/js/alchemy.js#L47","sourceId":1}],"count":1},{"paramName":"outputMode","paramValues":[{"value":"json","count":1,"source":["https://github.com/sfaries/AlchemyNews/blob/891a9ef358cc76e03d521d1569d5708134171732/js/alchemy.js#L47"]}],"bestSources":[{"url":"https://github.com/sfaries/AlchemyNews/blob/891a9ef358cc76e03d521d1569d5708134171732/js/alchemy.js#L47","sourceId":1}],"count":1},{"paramName":"return","paramValues":[{"value":"enriched.url.title,enriched.url.url,enriched.url.author","count":1,"source":["https://github.com/sfaries/AlchemyNews/blob/891a9ef358cc76e03d521d1569d5708134171732/js/alchemy.js#L47"]}],"bestSources":[{"url":"https://github.com/sfaries/AlchemyNews/blob/891a9ef358cc76e03d521d1569d5708134171732/js/alchemy.js#L47","sourceId":1}],"count":1},{"paramName":"start","paramValues":[{"value":"now-10d","count":1,"source":["https://github.com/sfaries/AlchemyNews/blob/891a9ef358cc76e03d521d1569d5708134171732/js/alchemy.js#L47"]}],"bestSources":[{"url":"https://github.com/sfaries/AlchemyNews/blob/891a9ef358cc76e03d521d1569d5708134171732/js/alchemy.js#L47","sourceId":1}],"count":1}],"topJQueryAjaxParams":null,"topResponseFields":[{"fieldName":"result.docs.length","count":5,"total":26,"bestSources":[{"url":"https://github.com/FlyMoe/Candidus-Informatio/blob/4ecbac214df76e1493cfffc11ba45321a7543b30/assets/javascript/app.js#L414","sourceId":2},{"url":"https://github.com/alexlcortes/another-test-repo/blob/c216a20deeec16d648256197df6bd2033131ffde/assets/javascript/app.js#L414","sourceId":3}],"source":["https://github.com/cmoulika009/ASE-Lab-Assignments/blob/9e0731d8dde2fd5b7b3145ce25e7d598f8903903/Lab-3-Mashup%20Application/Source/js/app.js#L222","https://github.com/cmoulika009/ASE-Lab-Assignments/blob/324ade52edd760d697ed597936265781412285f3/Lab-9-Cloud-Based-App-II/Source/Cloud%20App/js/app.js#L222","https://github.com/ljm7b2/advSftwrEngnrTest/blob/dedd1afd4f0ddd52b9d1b94f8dce2cb0d5533de7/Source/LAB_5_MASHUP_SOURCE_CODE/lab_5_API_alchemyNEWS_SPOTIFY_playlists/app.js#L221","https://github.com/FlyMoe/Candidus-Informatio/blob/4ecbac214df76e1493cfffc11ba45321a7543b30/assets/javascript/app.js#L414","https://github.com/alexlcortes/another-test-repo/blob/c216a20deeec16d648256197df6bd2033131ffde/assets/javascript/app.js#L414"]},{"fieldName":"result.docs","count":1,"total":26,"bestSources":[{"url":"https://github.com/sfaries/AlchemyNews/blob/891a9ef358cc76e03d521d1569d5708134171732/js/alchemy.js#L47","sourceId":1}],"source":["https://github.com/sfaries/AlchemyNews/blob/891a9ef358cc76e03d521d1569d5708134171732/js/alchemy.js#L47"]}]}}}},"definitions":{"NewsResponse":{"type":"object","properties":{"status":{"type":"string"},"usage":{"type":"string"},"totalTransactions":{"type":"string"},"result":{"type":"object","properties":{"docs":{"type":"array","items":{"type":"object","properties":{"id":{"type":"string"},"source":{"type":"object","properties":{"enriched":{"type":"object","properties":{"url":{"type":"object","properties":{"title":{"type":"string"}},"required":["title"]}},"required":["url"]}},"required":["enriched"]},"timestamp":{"type":"integer"}},"required":["id","source","timestamp"]}},"next":{"type":"string"},"status":{"type":"string"}},"required":["docs","next","status"]}},"required":["status","usage","totalTransactions","result"]}},"x-apih-id":"ibm_watson_alchemy_data_news_api","x-apih-ghusage":{"count":0,"topUsages":[{"repository":"likethecolor/Alchemy-API","repoUrl":"https://github.com/likethecolor/Alchemy-API","description":"Java client for the service provided by AlchemyAPI (a cloud-based text mining platform http://www.alchemyapi.com/)","language":"Java","stargazers":9,"watchers":9,"forks":13,"subscribers":3,"sources":["https://github.com/likethecolor/Alchemy-API/blob/5208cfc92a878ceeaff052787af29da92d98db7e/src/test/java/com/likethecolor/alchemy/api/parser/json/AbstractParserTest.java","https://github.com/likethecolor/Alchemy-API/blob/5208cfc92a878ceeaff052787af29da92d98db7e/src/test/java/com/likethecolor/alchemy/api/parser/json/RelationsParserTest.java","https://github.com/likethecolor/Alchemy-API/blob/5208cfc92a878ceeaff052787af29da92d98db7e/src/test/java/com/likethecolor/alchemy/api/parser/json/ConceptParserTest.java","https://github.com/likethecolor/Alchemy-API/blob/5208cfc92a878ceeaff052787af29da92d98db7e/src/test/java/com/likethecolor/alchemy/api/parser/json/KeywordParserTest.java","https://github.com/likethecolor/Alchemy-API/blob/5208cfc92a878ceeaff052787af29da92d98db7e/src/test/java/com/likethecolor/alchemy/api/parser/json/TaxonomyParserTest.java","https://github.com/likethecolor/Alchemy-API/blob/5208cfc92a878ceeaff052787af29da92d98db7e/src/test/java/com/likethecolor/alchemy/api/parser/json/TaxonomiesParserTest.java","https://github.com/likethecolor/Alchemy-API/blob/5208cfc92a878ceeaff052787af29da92d98db7e/src/test/java/com/likethecolor/alchemy/api/parser/json/NamedEntityParserTest.java","https://github.com/likethecolor/Alchemy-API/blob/5208cfc92a878ceeaff052787af29da92d98db7e/src/test/java/com/likethecolor/alchemy/api/entity/ResponseTest.java","https://github.com/likethecolor/Alchemy-API/blob/5208cfc92a878ceeaff052787af29da92d98db7e/src/test/java/com/likethecolor/alchemy/api/parser/json/MicroformatParserTest.java","https://github.com/likethecolor/Alchemy-API/blob/5208cfc92a878ceeaff052787af29da92d98db7e/src/test/java/com/likethecolor/alchemy/api/parser/json/LanguageParserTest.java","https://github.com/likethecolor/Alchemy-API/blob/5208cfc92a878ceeaff052787af29da92d98db7e/src/test/java/com/likethecolor/alchemy/api/entity/HeaderAlchemyEntityTest.java","https://github.com/likethecolor/Alchemy-API/blob/5208cfc92a878ceeaff052787af29da92d98db7e/src/test/java/com/likethecolor/alchemy/api/parser/json/TitleParserTest.java","https://github.com/likethecolor/Alchemy-API/blob/5208cfc92a878ceeaff052787af29da92d98db7e/src/test/java/com/likethecolor/alchemy/api/parser/json/AuthorParserTest.java","https://github.com/likethecolor/Alchemy-API/blob/5208cfc92a878ceeaff052787af29da92d98db7e/src/test/java/com/likethecolor/alchemy/api/parser/json/SentimentParserTest.java","https://github.com/likethecolor/Alchemy-API/blob/ee054196b8a00fccd40e18748d9fa71aed540fef/src/test/java/com/likethecolor/alchemy/api/parser/json/AbstractParserTest.java","https://github.com/likethecolor/Alchemy-API/blob/ee054196b8a00fccd40e18748d9fa71aed540fef/src/test/java/com/likethecolor/alchemy/api/parser/json/RelationsParserTest.java","https://github.com/likethecolor/Alchemy-API/blob/ee054196b8a00fccd40e18748d9fa71aed540fef/src/test/java/com/likethecolor/alchemy/api/parser/json/KeywordParserTest.java","https://github.com/likethecolor/Alchemy-API/blob/ee054196b8a00fccd40e18748d9fa71aed540fef/src/test/java/com/likethecolor/alchemy/api/parser/json/ConceptParserTest.java","https://github.com/likethecolor/Alchemy-API/blob/ee054196b8a00fccd40e18748d9fa71aed540fef/src/test/java/com/likethecolor/alchemy/api/parser/json/TaxonomyParserTest.java","https://github.com/likethecolor/Alchemy-API/blob/ee054196b8a00fccd40e18748d9fa71aed540fef/src/test/java/com/likethecolor/alchemy/api/parser/json/TaxonomiesParserTest.java","https://github.com/likethecolor/Alchemy-API/blob/ee054196b8a00fccd40e18748d9fa71aed540fef/src/test/java/com/likethecolor/alchemy/api/parser/json/NamedEntityParserTest.java","https://github.com/likethecolor/Alchemy-API/blob/ee054196b8a00fccd40e18748d9fa71aed540fef/src/test/java/com/likethecolor/alchemy/api/entity/ResponseTest.java","https://github.com/likethecolor/Alchemy-API/blob/ee054196b8a00fccd40e18748d9fa71aed540fef/src/test/java/com/likethecolor/alchemy/api/parser/json/MicroformatParserTest.java","https://github.com/likethecolor/Alchemy-API/blob/ee054196b8a00fccd40e18748d9fa71aed540fef/src/test/java/com/likethecolor/alchemy/api/parser/json/LanguageParserTest.java","https://github.com/likethecolor/Alchemy-API/blob/ee054196b8a00fccd40e18748d9fa71aed540fef/src/test/java/com/likethecolor/alchemy/api/entity/HeaderAlchemyEntityTest.java","https://github.com/likethecolor/Alchemy-API/blob/ee054196b8a00fccd40e18748d9fa71aed540fef/src/test/java/com/likethecolor/alchemy/api/parser/json/TitleParserTest.java","https://github.com/likethecolor/Alchemy-API/blob/ee054196b8a00fccd40e18748d9fa71aed540fef/src/test/java/com/likethecolor/alchemy/api/parser/json/SentimentParserTest.java","https://github.com/likethecolor/Alchemy-API/blob/ee054196b8a00fccd40e18748d9fa71aed540fef/src/test/java/com/likethecolor/alchemy/api/parser/json/AuthorParserTest.java"]},{"repository":"xiagu/plotlines","repoUrl":"https://github.com/xiagu/plotlines","description":"Generate a narrative chart for a well-known book or movie","language":"HTML","stargazers":6,"watchers":6,"forks":2,"subscribers":4,"sources":["https://github.com/xiagu/plotlines/blob/053f60b65e7fb95e701d71d5b61ff5efef2adf2d/data/mock.js"]},{"repository":"zemanel/HNMood","repoUrl":"https://github.com/zemanel/HNMood","description":null,"language":"Python","stargazers":4,"watchers":4,"forks":0,"subscribers":1,"sources":["https://github.com/zemanel/HNMood/blob/bd6d1f230f8a612f665e334cd653afb59bc056b2/docs/alchemy_response.js"]},{"repository":"mollywhitnack/the-daily-feels","repoUrl":"https://github.com/mollywhitnack/the-daily-feels","description":null,"language":"JavaScript","stargazers":2,"watchers":2,"forks":2,"subscribers":4,"sources":["https://github.com/mollywhitnack/the-daily-feels/blob/e5cb50c7ae82e04ab17e529584fb3ad023165c3f/src/api/mockNewsApi.js","https://github.com/mollywhitnack/the-daily-feels/blob/74eb040adddc473d278921b94fbdbb566cd17882/src/api/mockNewsApi.js"]},{"repository":"wjohnson1000/Frontend_Personal_Project","repoUrl":"https://github.com/wjohnson1000/Frontend_Personal_Project","description":"Repo for g15 1st quarter project","language":"JavaScript","stargazers":2,"watchers":2,"forks":0,"subscribers":2,"sources":["https://github.com/wjohnson1000/Frontend_Personal_Project/blob/fd1244fae8a9932819ed287c6f53611b1acd6158/source/scripts/main.js"]},{"repository":"Soaring-Outliers/news_graph","repoUrl":"https://github.com/Soaring-Outliers/news_graph","description":"Graph gathering news","language":"JavaScript","stargazers":1,"watchers":1,"forks":0,"subscribers":1,"sources":["https://github.com/Soaring-Outliers/news_graph/blob/ae7cde461e49b6ee8fe932fcf6c581f3a5574da4/graph/models.py"]},{"repository":"collective/eea.alchemy","repoUrl":"https://github.com/collective/eea.alchemy","description":"Auto-discover geographical coverage, temporal coverage and keywords from documents common metadata (title, description, body, etc).","language":"Python","stargazers":1,"watchers":1,"forks":1,"subscribers":168,"sources":["https://github.com/collective/eea.alchemy/blob/6bf1ac036272423877639414d6e06fc55969d756/eea/alchemy/tests/fake.py","https://github.com/collective/eea.alchemy/blob/25a833a7fa73024ad8cc2dd239b854a702348e59/eea/alchemy/tests/fake.py"]},{"repository":"ErikTillberg/SentimentVsStockPriceAnalyzer","repoUrl":"https://github.com/ErikTillberg/SentimentVsStockPriceAnalyzer","description":"Using Watson's text sentiment analysis to map twitter sentiment against stock prices","language":"Python","stargazers":0,"watchers":0,"forks":0,"subscribers":2,"sources":["https://github.com/ErikTillberg/SentimentVsStockPriceAnalyzer/blob/f7fbb1594bb0ecba9f983664e155c694694d759a/alchemy_sentiment.py","https://github.com/ErikTillberg/SentimentVsStockPriceAnalyzer/blob/79db784d4d5f109c6bf0e4776b4244a2dec5f8a9/alchemy_sentiment.py"]},{"repository":"annaet/spotlight-news","repoUrl":"https://github.com/annaet/spotlight-news","description":null,"language":"JavaScript","stargazers":0,"watchers":0,"forks":0,"subscribers":4,"sources":["https://github.com/annaet/spotlight-news/blob/05d43e011357ee32e87921e54bc9fbb4a4c77066/app/scripts/controllers/dendrogram.js"]},{"repository":"adalrsjr1/www","repoUrl":"https://github.com/adalrsjr1/www","description":null,"language":"PHP","stargazers":0,"watchers":0,"forks":0,"subscribers":1,"sources":["https://github.com/adalrsjr1/www/blob/eaaf400107ba0cd03c678af076e66ec1d98f8326/ccbeu.com/ccbeu-perfil/AppCore.php"]}]},"x-apih-relationships":[{"relatedApiId":"ibm_watson_alchemy_language_api","commonUsages":[{"github_repo_name":"wjohnson1000/Frontend_Personal_Project","stargazers_count":2},{"github_repo_name":"wjohnson1000/wjohnson1000.github.io","stargazers_count":0},{"github_repo_name":"sfaries/AlchemyNews","stargazers_count":0},{"github_repo_name":"sickle5stone/FishyBusiness","stargazers_count":0},{"github_repo_name":"kongyujian/Fishackathon2016_Geospatial","stargazers_count":0},{"github_repo_name":"alexbtk/amos-ss16-proj9","stargazers_count":0},{"github_repo_name":"Liux0047/watsonapp","stargazers_count":0},{"github_repo_name":"ljm7b2/advSftwrEngnrTest","stargazers_count":0},{"github_repo_name":"cmoulika009/ASE-Lab-Assignments","stargazers_count":0},{"github_repo_name":"FlyMoe/Candidus-Informatio","stargazers_count":0},{"github_repo_name":"alexlcortes/another-test-repo","stargazers_count":0}]},{"relatedApiId":"ibm_watson_alchemy_vision_api","commonUsages":[{"github_repo_name":"wjohnson1000/Frontend_Personal_Project","stargazers_count":2},{"github_repo_name":"wjohnson1000/wjohnson1000.github.io","stargazers_count":0},{"github_repo_name":"sfaries/AlchemyNews","stargazers_count":0},{"github_repo_name":"sickle5stone/FishyBusiness","stargazers_count":0},{"github_repo_name":"kongyujian/Fishackathon2016_Geospatial","stargazers_count":0},{"github_repo_name":"alexbtk/amos-ss16-proj9","stargazers_count":0},{"github_repo_name":"Liux0047/watsonapp","stargazers_count":0},{"github_repo_name":"ljm7b2/advSftwrEngnrTest","stargazers_count":0},{"github_repo_name":"cmoulika009/ASE-Lab-Assignments","stargazers_count":0},{"github_repo_name":"FlyMoe/Candidus-Informatio","stargazers_count":0},{"github_repo_name":"alexlcortes/another-test-repo","stargazers_count":0}]},{"relatedApiId":"yahoo_weather_api","commonUsages":[{"github_repo_name":"sickle5stone/FishyBusiness","stargazers_count":0},{"github_repo_name":"kongyujian/Fishackathon2016_Geospatial","stargazers_count":0}]},{"relatedApiId":"google_civic_info_api","commonUsages":[{"github_repo_name":"FlyMoe/Candidus-Informatio","stargazers_count":0},{"github_repo_name":"alexlcortes/another-test-repo","stargazers_count":0}]},{"relatedApiId":"google_civicinfo_api","commonUsages":[{"github_repo_name":"FlyMoe/Candidus-Informatio","stargazers_count":0},{"github_repo_name":"alexlcortes/another-test-repo","stargazers_count":0}]},{"relatedApiId":"google_blogger_api","commonUsages":[{"github_repo_name":"atrijitdasgupta/streetbuzz-investor","stargazers_count":0}]},{"relatedApiId":"amazon_product_advertising_api","commonUsages":[{"github_repo_name":"atrijitdasgupta/streetbuzz-investor","stargazers_count":0}]},{"relatedApiId":"quizlet_api_v2","commonUsages":[{"github_repo_name":"jaxball/hackthenorth16","stargazers_count":0}]}],"x-apih-sdks":[{"name":"rest-api-client","downloads":{"last-day":0,"last-month":100,"last-week":26},"description":"Simple REST client built on the request module","url":"https://www.npmjs.com/package/rest-api-client","repoUrl":"https://github.com/ryanlelek/rest-api-client","language":"JavaScript"},{"language":"JavaScript","description":"Node.js REST API client for Parse.com","url":"https://www.npmjs.com/package/parse-rest-api","name":"parse-rest-api","downloads":{"last-day":0,"last-month":21,"last-week":3}},{"name":"json-rest-api","downloads":{"last-day":0,"last-month":106,"last-week":16},"description":"A simple lightweight REST API that receives and responds to JSON HTTP requests, supports all verbs. Very simple.","url":"https://www.npmjs.com/package/json-rest-api","repoUrl":"git://github.com/stdarg/json-rest-api","language":"JavaScript"},{"name":"pimatic-rest-api","downloads":{"last-day":0,"last-month":120,"last-week":16},"description":"Provides a rest-api for the webinterface.","url":"https://www.npmjs.com/package/pimatic-rest-api","repoUrl":"git://github.com/pimatic/pimatic-rest-api","language":"JavaScript"},{"name":"keystone-rest-api","downloads":{"last-day":1,"last-month":58,"last-week":10},"description":"Creates a powerful Rest API based on Keystone Lists","url":"https://www.npmjs.com/package/keystone-rest-api","repoUrl":"git+https://github.com/sarriaroman/Keystone-Rest-API","language":"JavaScript","license":"ISC"},{"name":"sails-hook-cti-rest-api-responses","downloads":{"last-day":0,"last-month":26,"last-week":6},"description":"REST friendly api responses for sails","url":"https://www.npmjs.com/package/sails-hook-cti-rest-api-responses","repoUrl":"git+https://github.com/CanTireInnovations/sails-hook-cti-rest-api-responses","language":"JavaScript","license":"ISC"},{"name":"ember-cli-rest-api-blueprint","downloads":{"last-day":2,"last-month":274,"last-week":59},"description":"Ember CLI blueprint addon for a DS.RESTAdapter compatible REST API","url":"https://www.npmjs.com/package/ember-cli-rest-api-blueprint","repoUrl":"git://github.com/manuelmitasch/ember-cli-rest-api-blueprint","language":"JavaScript","license":"MIT"},{"name":"pulsar-rest-api-client-node","downloads":{"last-day":0,"last-month":97,"last-week":10},"description":"pulsar-rest-api-client-node [![Build Status](https://travis-ci.org/cargomedia/pulsar-rest-api-client-node.svg?branch=master)](https://travis-ci.org/cargomedia/pulsar-rest-api-client-node) ===========================","url":"https://www.npmjs.com/package/pulsar-rest-api-client-node","repoUrl":"git+ssh://git@github.com/cargomedia/pulsar-rest-api-client-node","language":"JavaScript","license":"MIT"},{"name":"pulsar-rest-api","downloads":{"last-day":0,"last-month":160,"last-week":22},"description":"REST API for executing Pulsar tasks.","url":"https://www.npmjs.com/package/pulsar-rest-api","repoUrl":"git+ssh://git@github.com/cargomedia/pulsar-rest-api","language":"JavaScript","license":"MIT"},{"name":"git-rest-api","downloads":{"last-day":1,"last-month":137,"last-week":27},"description":"A library providing a restful Git API mimicking as most as possible the old good git","url":"https://www.npmjs.com/package/git-rest-api","repoUrl":"https://github.com/korya/node-git-rest-api","language":"JavaScript"}],"x-apih-organization":"public","meta":{"revision":0,"created":1495048571337,"version":0},"$loki":479}
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "IBM Alchemy Data News",
+    "version": "1.0",
+    "description": "Alchemy Data News provides news and blog content enriched with natural language processing to allow for highly targeted search and trend analysis. Now you can query the world's news sources and blogs like a database.",
+    "x-tags": ["News", "Natural Language Processing", "Blogs"],
+    "contact": { "url": "https://support.ng.bluemix.net/supportticket/" }
+  },
+  "externalDocs": {
+    "url": "https://www.ibm.com/watson/developercloud/alchemydata-news/api/v1/"
+  },
+  "host": "gateway-a.watsonplatform.net",
+  "schemes": ["https"],
+  "basePath": "/calls",
+  "paths": {
+    "/data/GetNews": {
+      "get": {
+        "tags": ["News"],
+        "summary": "Analyze news",
+        "description": "Analyze news using Natural Language Processing (NLP) queries and sophisticated filters.",
+        "operationId": "GetNews",
+        "produces": ["application/json", "application/xml"],
+        "parameters": [
+          {
+            "in": "query",
+            "description": "API key (optional in the API explorer)",
+            "name": "apikey",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "in": "query",
+            "description": "Output mode",
+            "name": "outputMode",
+            "type": "string",
+            "enum": ["xml", "json"],
+            "default": "json"
+          },
+          {
+            "in": "query",
+            "description": "Start date",
+            "name": "start",
+            "required": true,
+            "type": "string",
+            "default": "now-1d"
+          },
+          {
+            "in": "query",
+            "description": "End date",
+            "name": "end",
+            "required": true,
+            "type": "string",
+            "default": "now"
+          },
+          {
+            "in": "query",
+            "description": "Maximum results",
+            "name": "maxResults",
+            "default": 10,
+            "type": "integer"
+          },
+          {
+            "in": "query",
+            "description": "Time slice",
+            "name": "timeSlice",
+            "type": "string"
+          },
+          {
+            "in": "query",
+            "description": "Fields to return for each document (comma separated). e.g. enriched.url.title,enriched.url.author,enriched.url.keywords",
+            "name": "return",
+            "type": "string",
+            "collectionFormat": "csv"
+          },
+          {
+            "in": "query",
+            "description": "Example filter query parameter (title relations)",
+            "name": "q.enriched.url.enrichedTitle.relations.relation",
+            "type": "string"
+          },
+          {
+            "in": "query",
+            "description": "Example filter query parameter (title entity)",
+            "name": "q.enriched.url.enrichedTitle.entities.entity",
+            "type": "string"
+          },
+          {
+            "in": "query",
+            "description": "Example filter query parameter (title taxonomy)",
+            "name": "q.enriched.url.enrichedTitle.taxonomy.taxonomy_",
+            "type": "string"
+          },
+          {
+            "in": "query",
+            "description": "Example filter query parameter (sentiment)",
+            "name": "q.enriched.url.enrichedTitle.docSentiment.type",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": { "$ref": "#/definitions/NewsResponse" }
+          }
+        },
+        "x-apih-advice": {
+          "totalUsageCount": 26,
+          "topQueryParams": [
+            {
+              "paramName": "apikey",
+              "paramValues": [
+                {
+                  "value": "<Hiding desensitized value>",
+                  "count": 3,
+                  "source": [
+                    "https://github.com/cmoulika009/ASE-Lab-Assignments/blob/9e0731d8dde2fd5b7b3145ce25e7d598f8903903/Lab-3-Mashup%20Application/Source/js/app.js#L222",
+                    "https://github.com/cmoulika009/ASE-Lab-Assignments/blob/324ade52edd760d697ed597936265781412285f3/Lab-9-Cloud-Based-App-II/Source/Cloud%20App/js/app.js#L222",
+                    "https://github.com/ljm7b2/advSftwrEngnrTest/blob/dedd1afd4f0ddd52b9d1b94f8dce2cb0d5533de7/Source/LAB_5_MASHUP_SOURCE_CODE/lab_5_API_alchemyNEWS_SPOTIFY_playlists/app.js#L221"
+                  ]
+                },
+                {
+                  "value": "<Hiding desensitized value>",
+                  "count": 2,
+                  "source": [
+                    "https://github.com/sickle5stone/FishyBusiness/blob/230dd18dfdb1a167c3ab39390fc87374dd67d9c0/js/news.js#L64",
+                    "https://github.com/kongyujian/Fishackathon2016_Geospatial/blob/3eba2dd89c82761b7b11d32dc3b5817727ec7d27/js/news.js#L64"
+                  ]
+                },
+                {
+                  "value": "<Hiding desensitized value>",
+                  "count": 2,
+                  "source": [
+                    "https://github.com/FlyMoe/Candidus-Informatio/blob/4ecbac214df76e1493cfffc11ba45321a7543b30/assets/javascript/app.js#L414",
+                    "https://github.com/alexlcortes/another-test-repo/blob/c216a20deeec16d648256197df6bd2033131ffde/assets/javascript/app.js#L414"
+                  ]
+                },
+                {
+                  "value": "<Hiding desensitized value>",
+                  "count": 2,
+                  "source": [
+                    "https://github.com/wjohnson1000/Frontend_Personal_Project/blob/fd1244fae8a9932819ed287c6f53611b1acd6158/source/scripts/main.js#L52",
+                    "https://github.com/wjohnson1000/wjohnson1000.github.io/blob/cb99bea35ebb38d6a246fd1da701d83550d769a5/scripts/main.js#L56"
+                  ]
+                }
+              ],
+              "bestSources": null,
+              "count": 10
+            },
+            {
+              "paramName": "end",
+              "paramValues": [
+                {
+                  "value": "now",
+                  "count": 10,
+                  "source": [
+                    "https://github.com/sickle5stone/FishyBusiness/blob/230dd18dfdb1a167c3ab39390fc87374dd67d9c0/js/news.js#L64",
+                    "https://github.com/wjohnson1000/Frontend_Personal_Project/blob/fd1244fae8a9932819ed287c6f53611b1acd6158/source/scripts/main.js#L52",
+                    "https://github.com/alexbtk/amos-ss16-proj9/blob/d667a46692f0ea440696a60d6212582f1352006d/src/main/webapp/js/AMOSAlchemy.js#L26",
+                    "https://github.com/cmoulika009/ASE-Lab-Assignments/blob/9e0731d8dde2fd5b7b3145ce25e7d598f8903903/Lab-3-Mashup%20Application/Source/js/app.js#L222",
+                    "https://github.com/kongyujian/Fishackathon2016_Geospatial/blob/3eba2dd89c82761b7b11d32dc3b5817727ec7d27/js/news.js#L64",
+                    "https://github.com/wjohnson1000/wjohnson1000.github.io/blob/cb99bea35ebb38d6a246fd1da701d83550d769a5/scripts/main.js#L56",
+                    "https://github.com/cmoulika009/ASE-Lab-Assignments/blob/324ade52edd760d697ed597936265781412285f3/Lab-9-Cloud-Based-App-II/Source/Cloud%20App/js/app.js#L222",
+                    "https://github.com/ljm7b2/advSftwrEngnrTest/blob/dedd1afd4f0ddd52b9d1b94f8dce2cb0d5533de7/Source/LAB_5_MASHUP_SOURCE_CODE/lab_5_API_alchemyNEWS_SPOTIFY_playlists/app.js#L221",
+                    "https://github.com/FlyMoe/Candidus-Informatio/blob/4ecbac214df76e1493cfffc11ba45321a7543b30/assets/javascript/app.js#L414",
+                    "https://github.com/alexlcortes/another-test-repo/blob/c216a20deeec16d648256197df6bd2033131ffde/assets/javascript/app.js#L414"
+                  ]
+                }
+              ],
+              "bestSources": [
+                {
+                  "url": "https://github.com/FlyMoe/Candidus-Informatio/blob/4ecbac214df76e1493cfffc11ba45321a7543b30/assets/javascript/app.js#L414",
+                  "sourceId": 2
+                },
+                {
+                  "url": "https://github.com/alexlcortes/another-test-repo/blob/c216a20deeec16d648256197df6bd2033131ffde/assets/javascript/app.js#L414",
+                  "sourceId": 3
+                }
+              ],
+              "count": 10
+            },
+            {
+              "paramName": "outputMode",
+              "paramValues": [
+                {
+                  "value": "json",
+                  "count": 10,
+                  "source": [
+                    "https://github.com/sickle5stone/FishyBusiness/blob/230dd18dfdb1a167c3ab39390fc87374dd67d9c0/js/news.js#L64",
+                    "https://github.com/wjohnson1000/Frontend_Personal_Project/blob/fd1244fae8a9932819ed287c6f53611b1acd6158/source/scripts/main.js#L52",
+                    "https://github.com/alexbtk/amos-ss16-proj9/blob/d667a46692f0ea440696a60d6212582f1352006d/src/main/webapp/js/AMOSAlchemy.js#L26",
+                    "https://github.com/cmoulika009/ASE-Lab-Assignments/blob/9e0731d8dde2fd5b7b3145ce25e7d598f8903903/Lab-3-Mashup%20Application/Source/js/app.js#L222",
+                    "https://github.com/kongyujian/Fishackathon2016_Geospatial/blob/3eba2dd89c82761b7b11d32dc3b5817727ec7d27/js/news.js#L64",
+                    "https://github.com/wjohnson1000/wjohnson1000.github.io/blob/cb99bea35ebb38d6a246fd1da701d83550d769a5/scripts/main.js#L56",
+                    "https://github.com/cmoulika009/ASE-Lab-Assignments/blob/324ade52edd760d697ed597936265781412285f3/Lab-9-Cloud-Based-App-II/Source/Cloud%20App/js/app.js#L222",
+                    "https://github.com/ljm7b2/advSftwrEngnrTest/blob/dedd1afd4f0ddd52b9d1b94f8dce2cb0d5533de7/Source/LAB_5_MASHUP_SOURCE_CODE/lab_5_API_alchemyNEWS_SPOTIFY_playlists/app.js#L221",
+                    "https://github.com/FlyMoe/Candidus-Informatio/blob/4ecbac214df76e1493cfffc11ba45321a7543b30/assets/javascript/app.js#L414",
+                    "https://github.com/alexlcortes/another-test-repo/blob/c216a20deeec16d648256197df6bd2033131ffde/assets/javascript/app.js#L414"
+                  ]
+                }
+              ],
+              "bestSources": [
+                {
+                  "url": "https://github.com/FlyMoe/Candidus-Informatio/blob/4ecbac214df76e1493cfffc11ba45321a7543b30/assets/javascript/app.js#L414",
+                  "sourceId": 2
+                },
+                {
+                  "url": "https://github.com/alexlcortes/another-test-repo/blob/c216a20deeec16d648256197df6bd2033131ffde/assets/javascript/app.js#L414",
+                  "sourceId": 3
+                }
+              ],
+              "count": 10
+            },
+            {
+              "paramName": "return",
+              "paramValues": [
+                {
+                  "value": "enriched.url.url,enriched.url.title",
+                  "count": 7,
+                  "source": [
+                    "https://github.com/wjohnson1000/Frontend_Personal_Project/blob/fd1244fae8a9932819ed287c6f53611b1acd6158/source/scripts/main.js#L52",
+                    "https://github.com/cmoulika009/ASE-Lab-Assignments/blob/9e0731d8dde2fd5b7b3145ce25e7d598f8903903/Lab-3-Mashup%20Application/Source/js/app.js#L222",
+                    "https://github.com/wjohnson1000/wjohnson1000.github.io/blob/cb99bea35ebb38d6a246fd1da701d83550d769a5/scripts/main.js#L56",
+                    "https://github.com/cmoulika009/ASE-Lab-Assignments/blob/324ade52edd760d697ed597936265781412285f3/Lab-9-Cloud-Based-App-II/Source/Cloud%20App/js/app.js#L222",
+                    "https://github.com/ljm7b2/advSftwrEngnrTest/blob/dedd1afd4f0ddd52b9d1b94f8dce2cb0d5533de7/Source/LAB_5_MASHUP_SOURCE_CODE/lab_5_API_alchemyNEWS_SPOTIFY_playlists/app.js#L221",
+                    "https://github.com/FlyMoe/Candidus-Informatio/blob/4ecbac214df76e1493cfffc11ba45321a7543b30/assets/javascript/app.js#L414",
+                    "https://github.com/alexlcortes/another-test-repo/blob/c216a20deeec16d648256197df6bd2033131ffde/assets/javascript/app.js#L414"
+                  ]
+                },
+                {
+                  "value": "enriched.url.url,enriched.url.title,enriched.url.text",
+                  "count": 2,
+                  "source": [
+                    "https://github.com/sickle5stone/FishyBusiness/blob/230dd18dfdb1a167c3ab39390fc87374dd67d9c0/js/news.js#L64",
+                    "https://github.com/kongyujian/Fishackathon2016_Geospatial/blob/3eba2dd89c82761b7b11d32dc3b5817727ec7d27/js/news.js#L64"
+                  ]
+                },
+                {
+                  "value": "q.enriched.url.title,q.enriched.url.entities",
+                  "count": 1,
+                  "source": [
+                    "https://github.com/alexbtk/amos-ss16-proj9/blob/d667a46692f0ea440696a60d6212582f1352006d/src/main/webapp/js/AMOSAlchemy.js#L26"
+                  ]
+                }
+              ],
+              "bestSources": null,
+              "count": 10
+            },
+            {
+              "paramName": "start",
+              "paramValues": [
+                {
+                  "value": "now-1d",
+                  "count": 5,
+                  "source": [
+                    "https://github.com/wjohnson1000/Frontend_Personal_Project/blob/fd1244fae8a9932819ed287c6f53611b1acd6158/source/scripts/main.js#L52",
+                    "https://github.com/cmoulika009/ASE-Lab-Assignments/blob/9e0731d8dde2fd5b7b3145ce25e7d598f8903903/Lab-3-Mashup%20Application/Source/js/app.js#L222",
+                    "https://github.com/wjohnson1000/wjohnson1000.github.io/blob/cb99bea35ebb38d6a246fd1da701d83550d769a5/scripts/main.js#L56",
+                    "https://github.com/cmoulika009/ASE-Lab-Assignments/blob/324ade52edd760d697ed597936265781412285f3/Lab-9-Cloud-Based-App-II/Source/Cloud%20App/js/app.js#L222",
+                    "https://github.com/ljm7b2/advSftwrEngnrTest/blob/dedd1afd4f0ddd52b9d1b94f8dce2cb0d5533de7/Source/LAB_5_MASHUP_SOURCE_CODE/lab_5_API_alchemyNEWS_SPOTIFY_playlists/app.js#L221"
+                  ]
+                },
+                {
+                  "value": "now-3.0d",
+                  "count": 2,
+                  "source": [
+                    "https://github.com/FlyMoe/Candidus-Informatio/blob/4ecbac214df76e1493cfffc11ba45321a7543b30/assets/javascript/app.js#L414",
+                    "https://github.com/alexlcortes/another-test-repo/blob/c216a20deeec16d648256197df6bd2033131ffde/assets/javascript/app.js#L414"
+                  ]
+                },
+                {
+                  "value": "now-7d",
+                  "count": 2,
+                  "source": [
+                    "https://github.com/sickle5stone/FishyBusiness/blob/230dd18dfdb1a167c3ab39390fc87374dd67d9c0/js/news.js#L64",
+                    "https://github.com/kongyujian/Fishackathon2016_Geospatial/blob/3eba2dd89c82761b7b11d32dc3b5817727ec7d27/js/news.js#L64"
+                  ]
+                },
+                {
+                  "value": "now-3d",
+                  "count": 1,
+                  "source": [
+                    "https://github.com/alexbtk/amos-ss16-proj9/blob/d667a46692f0ea440696a60d6212582f1352006d/src/main/webapp/js/AMOSAlchemy.js#L26"
+                  ]
+                }
+              ],
+              "bestSources": null,
+              "count": 10
+            },
+            {
+              "paramName": "count",
+              "paramValues": [
+                {
+                  "value": "5",
+                  "count": 9,
+                  "source": [
+                    "https://github.com/sickle5stone/FishyBusiness/blob/230dd18dfdb1a167c3ab39390fc87374dd67d9c0/js/news.js#L64",
+                    "https://github.com/wjohnson1000/Frontend_Personal_Project/blob/fd1244fae8a9932819ed287c6f53611b1acd6158/source/scripts/main.js#L52",
+                    "https://github.com/cmoulika009/ASE-Lab-Assignments/blob/9e0731d8dde2fd5b7b3145ce25e7d598f8903903/Lab-3-Mashup%20Application/Source/js/app.js#L222",
+                    "https://github.com/kongyujian/Fishackathon2016_Geospatial/blob/3eba2dd89c82761b7b11d32dc3b5817727ec7d27/js/news.js#L64",
+                    "https://github.com/wjohnson1000/wjohnson1000.github.io/blob/cb99bea35ebb38d6a246fd1da701d83550d769a5/scripts/main.js#L56",
+                    "https://github.com/cmoulika009/ASE-Lab-Assignments/blob/324ade52edd760d697ed597936265781412285f3/Lab-9-Cloud-Based-App-II/Source/Cloud%20App/js/app.js#L222",
+                    "https://github.com/ljm7b2/advSftwrEngnrTest/blob/dedd1afd4f0ddd52b9d1b94f8dce2cb0d5533de7/Source/LAB_5_MASHUP_SOURCE_CODE/lab_5_API_alchemyNEWS_SPOTIFY_playlists/app.js#L221",
+                    "https://github.com/FlyMoe/Candidus-Informatio/blob/4ecbac214df76e1493cfffc11ba45321a7543b30/assets/javascript/app.js#L414",
+                    "https://github.com/alexlcortes/another-test-repo/blob/c216a20deeec16d648256197df6bd2033131ffde/assets/javascript/app.js#L414"
+                  ]
+                }
+              ],
+              "bestSources": [
+                {
+                  "url": "https://github.com/FlyMoe/Candidus-Informatio/blob/4ecbac214df76e1493cfffc11ba45321a7543b30/assets/javascript/app.js#L414",
+                  "sourceId": 2
+                },
+                {
+                  "url": "https://github.com/alexlcortes/another-test-repo/blob/c216a20deeec16d648256197df6bd2033131ffde/assets/javascript/app.js#L414",
+                  "sourceId": 3
+                }
+              ],
+              "count": 9
+            },
+            {
+              "paramName": "q.enriched.url.enrichedTitle.keywords.keyword.text",
+              "paramValues": [
+                {
+                  "value": "{candidateNameArray.0 candidateNameArray.1}",
+                  "count": 2,
+                  "source": [
+                    "https://github.com/FlyMoe/Candidus-Informatio/blob/4ecbac214df76e1493cfffc11ba45321a7543b30/assets/javascript/app.js#L414",
+                    "https://github.com/alexlcortes/another-test-repo/blob/c216a20deeec16d648256197df6bd2033131ffde/assets/javascript/app.js#L414"
+                  ]
+                },
+                {
+                  "value": "{newsTopic}",
+                  "count": 2,
+                  "source": [
+                    "https://github.com/wjohnson1000/Frontend_Personal_Project/blob/fd1244fae8a9932819ed287c6f53611b1acd6158/source/scripts/main.js#L52",
+                    "https://github.com/wjohnson1000/wjohnson1000.github.io/blob/cb99bea35ebb38d6a246fd1da701d83550d769a5/scripts/main.js#L56"
+                  ]
+                }
+              ],
+              "bestSources": null,
+              "count": 7
+            },
+            {
+              "paramName": "q.enriched.url.title",
+              "paramValues": [
+                {
+                  "value": "Asian Carp",
+                  "count": 2,
+                  "source": [
+                    "https://github.com/sickle5stone/FishyBusiness/blob/230dd18dfdb1a167c3ab39390fc87374dd67d9c0/js/news.js#L64",
+                    "https://github.com/kongyujian/Fishackathon2016_Geospatial/blob/3eba2dd89c82761b7b11d32dc3b5817727ec7d27/js/news.js#L64"
+                  ]
+                }
+              ],
+              "bestSources": null,
+              "count": 2
+            }
+          ],
+          "topPayloadParams": [
+            {
+              "paramName": "end",
+              "paramValues": [
+                {
+                  "value": "now",
+                  "count": 1,
+                  "source": [
+                    "https://github.com/sfaries/AlchemyNews/blob/891a9ef358cc76e03d521d1569d5708134171732/js/alchemy.js#L47"
+                  ]
+                }
+              ],
+              "bestSources": [
+                {
+                  "url": "https://github.com/sfaries/AlchemyNews/blob/891a9ef358cc76e03d521d1569d5708134171732/js/alchemy.js#L47",
+                  "sourceId": 1
+                }
+              ],
+              "count": 1
+            },
+            {
+              "paramName": "maxResults",
+              "paramValues": [
+                {
+                  "value": "10",
+                  "count": 1,
+                  "source": [
+                    "https://github.com/sfaries/AlchemyNews/blob/891a9ef358cc76e03d521d1569d5708134171732/js/alchemy.js#L47"
+                  ]
+                }
+              ],
+              "bestSources": [
+                {
+                  "url": "https://github.com/sfaries/AlchemyNews/blob/891a9ef358cc76e03d521d1569d5708134171732/js/alchemy.js#L47",
+                  "sourceId": 1
+                }
+              ],
+              "count": 1
+            },
+            {
+              "paramName": "outputMode",
+              "paramValues": [
+                {
+                  "value": "json",
+                  "count": 1,
+                  "source": [
+                    "https://github.com/sfaries/AlchemyNews/blob/891a9ef358cc76e03d521d1569d5708134171732/js/alchemy.js#L47"
+                  ]
+                }
+              ],
+              "bestSources": [
+                {
+                  "url": "https://github.com/sfaries/AlchemyNews/blob/891a9ef358cc76e03d521d1569d5708134171732/js/alchemy.js#L47",
+                  "sourceId": 1
+                }
+              ],
+              "count": 1
+            },
+            {
+              "paramName": "return",
+              "paramValues": [
+                {
+                  "value": "enriched.url.title,enriched.url.url,enriched.url.author",
+                  "count": 1,
+                  "source": [
+                    "https://github.com/sfaries/AlchemyNews/blob/891a9ef358cc76e03d521d1569d5708134171732/js/alchemy.js#L47"
+                  ]
+                }
+              ],
+              "bestSources": [
+                {
+                  "url": "https://github.com/sfaries/AlchemyNews/blob/891a9ef358cc76e03d521d1569d5708134171732/js/alchemy.js#L47",
+                  "sourceId": 1
+                }
+              ],
+              "count": 1
+            },
+            {
+              "paramName": "start",
+              "paramValues": [
+                {
+                  "value": "now-10d",
+                  "count": 1,
+                  "source": [
+                    "https://github.com/sfaries/AlchemyNews/blob/891a9ef358cc76e03d521d1569d5708134171732/js/alchemy.js#L47"
+                  ]
+                }
+              ],
+              "bestSources": [
+                {
+                  "url": "https://github.com/sfaries/AlchemyNews/blob/891a9ef358cc76e03d521d1569d5708134171732/js/alchemy.js#L47",
+                  "sourceId": 1
+                }
+              ],
+              "count": 1
+            }
+          ],
+          "topJQueryAjaxParams": null,
+          "topResponseFields": [
+            {
+              "fieldName": "result.docs.length",
+              "count": 5,
+              "total": 26,
+              "bestSources": [
+                {
+                  "url": "https://github.com/FlyMoe/Candidus-Informatio/blob/4ecbac214df76e1493cfffc11ba45321a7543b30/assets/javascript/app.js#L414",
+                  "sourceId": 2
+                },
+                {
+                  "url": "https://github.com/alexlcortes/another-test-repo/blob/c216a20deeec16d648256197df6bd2033131ffde/assets/javascript/app.js#L414",
+                  "sourceId": 3
+                }
+              ],
+              "source": [
+                "https://github.com/cmoulika009/ASE-Lab-Assignments/blob/9e0731d8dde2fd5b7b3145ce25e7d598f8903903/Lab-3-Mashup%20Application/Source/js/app.js#L222",
+                "https://github.com/cmoulika009/ASE-Lab-Assignments/blob/324ade52edd760d697ed597936265781412285f3/Lab-9-Cloud-Based-App-II/Source/Cloud%20App/js/app.js#L222",
+                "https://github.com/ljm7b2/advSftwrEngnrTest/blob/dedd1afd4f0ddd52b9d1b94f8dce2cb0d5533de7/Source/LAB_5_MASHUP_SOURCE_CODE/lab_5_API_alchemyNEWS_SPOTIFY_playlists/app.js#L221",
+                "https://github.com/FlyMoe/Candidus-Informatio/blob/4ecbac214df76e1493cfffc11ba45321a7543b30/assets/javascript/app.js#L414",
+                "https://github.com/alexlcortes/another-test-repo/blob/c216a20deeec16d648256197df6bd2033131ffde/assets/javascript/app.js#L414"
+              ]
+            },
+            {
+              "fieldName": "result.docs",
+              "count": 1,
+              "total": 26,
+              "bestSources": [
+                {
+                  "url": "https://github.com/sfaries/AlchemyNews/blob/891a9ef358cc76e03d521d1569d5708134171732/js/alchemy.js#L47",
+                  "sourceId": 1
+                }
+              ],
+              "source": [
+                "https://github.com/sfaries/AlchemyNews/blob/891a9ef358cc76e03d521d1569d5708134171732/js/alchemy.js#L47"
+              ]
+            }
+          ]
+        }
+      }
+    }
+  },
+  "definitions": {
+    "NewsResponse": {
+      "type": "object",
+      "properties": {
+        "status": { "type": "string" },
+        "usage": { "type": "string" },
+        "totalTransactions": { "type": "string" },
+        "result": {
+          "type": "object",
+          "properties": {
+            "docs": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "id": { "type": "string" },
+                  "source": {
+                    "type": "object",
+                    "properties": {
+                      "enriched": {
+                        "type": "object",
+                        "properties": {
+                          "url": {
+                            "type": "object",
+                            "properties": { "title": { "type": "string" } },
+                            "required": ["title"]
+                          }
+                        },
+                        "required": ["url"]
+                      }
+                    },
+                    "required": ["enriched"]
+                  },
+                  "timestamp": { "type": "integer" }
+                },
+                "required": ["id", "source", "timestamp"]
+              }
+            },
+            "next": { "type": "string" },
+            "status": { "type": "string" }
+          },
+          "required": ["docs", "next", "status"]
+        }
+      },
+      "required": ["status", "usage", "totalTransactions", "result"]
+    }
+  },
+  "x-apih-id": "ibm_watson_alchemy_data_news_api",
+  "x-apih-ghusage": {
+    "count": 0,
+    "topUsages": [
+      {
+        "repository": "likethecolor/Alchemy-API",
+        "repoUrl": "https://github.com/likethecolor/Alchemy-API",
+        "description": "Java client for the service provided by AlchemyAPI (a cloud-based text mining platform http://www.alchemyapi.com/)",
+        "language": "Java",
+        "stargazers": 9,
+        "watchers": 9,
+        "forks": 13,
+        "subscribers": 3,
+        "sources": [
+          "https://github.com/likethecolor/Alchemy-API/blob/5208cfc92a878ceeaff052787af29da92d98db7e/src/test/java/com/likethecolor/alchemy/api/parser/json/AbstractParserTest.java",
+          "https://github.com/likethecolor/Alchemy-API/blob/5208cfc92a878ceeaff052787af29da92d98db7e/src/test/java/com/likethecolor/alchemy/api/parser/json/RelationsParserTest.java",
+          "https://github.com/likethecolor/Alchemy-API/blob/5208cfc92a878ceeaff052787af29da92d98db7e/src/test/java/com/likethecolor/alchemy/api/parser/json/ConceptParserTest.java",
+          "https://github.com/likethecolor/Alchemy-API/blob/5208cfc92a878ceeaff052787af29da92d98db7e/src/test/java/com/likethecolor/alchemy/api/parser/json/KeywordParserTest.java",
+          "https://github.com/likethecolor/Alchemy-API/blob/5208cfc92a878ceeaff052787af29da92d98db7e/src/test/java/com/likethecolor/alchemy/api/parser/json/TaxonomyParserTest.java",
+          "https://github.com/likethecolor/Alchemy-API/blob/5208cfc92a878ceeaff052787af29da92d98db7e/src/test/java/com/likethecolor/alchemy/api/parser/json/TaxonomiesParserTest.java",
+          "https://github.com/likethecolor/Alchemy-API/blob/5208cfc92a878ceeaff052787af29da92d98db7e/src/test/java/com/likethecolor/alchemy/api/parser/json/NamedEntityParserTest.java",
+          "https://github.com/likethecolor/Alchemy-API/blob/5208cfc92a878ceeaff052787af29da92d98db7e/src/test/java/com/likethecolor/alchemy/api/entity/ResponseTest.java",
+          "https://github.com/likethecolor/Alchemy-API/blob/5208cfc92a878ceeaff052787af29da92d98db7e/src/test/java/com/likethecolor/alchemy/api/parser/json/MicroformatParserTest.java",
+          "https://github.com/likethecolor/Alchemy-API/blob/5208cfc92a878ceeaff052787af29da92d98db7e/src/test/java/com/likethecolor/alchemy/api/parser/json/LanguageParserTest.java",
+          "https://github.com/likethecolor/Alchemy-API/blob/5208cfc92a878ceeaff052787af29da92d98db7e/src/test/java/com/likethecolor/alchemy/api/entity/HeaderAlchemyEntityTest.java",
+          "https://github.com/likethecolor/Alchemy-API/blob/5208cfc92a878ceeaff052787af29da92d98db7e/src/test/java/com/likethecolor/alchemy/api/parser/json/TitleParserTest.java",
+          "https://github.com/likethecolor/Alchemy-API/blob/5208cfc92a878ceeaff052787af29da92d98db7e/src/test/java/com/likethecolor/alchemy/api/parser/json/AuthorParserTest.java",
+          "https://github.com/likethecolor/Alchemy-API/blob/5208cfc92a878ceeaff052787af29da92d98db7e/src/test/java/com/likethecolor/alchemy/api/parser/json/SentimentParserTest.java",
+          "https://github.com/likethecolor/Alchemy-API/blob/ee054196b8a00fccd40e18748d9fa71aed540fef/src/test/java/com/likethecolor/alchemy/api/parser/json/AbstractParserTest.java",
+          "https://github.com/likethecolor/Alchemy-API/blob/ee054196b8a00fccd40e18748d9fa71aed540fef/src/test/java/com/likethecolor/alchemy/api/parser/json/RelationsParserTest.java",
+          "https://github.com/likethecolor/Alchemy-API/blob/ee054196b8a00fccd40e18748d9fa71aed540fef/src/test/java/com/likethecolor/alchemy/api/parser/json/KeywordParserTest.java",
+          "https://github.com/likethecolor/Alchemy-API/blob/ee054196b8a00fccd40e18748d9fa71aed540fef/src/test/java/com/likethecolor/alchemy/api/parser/json/ConceptParserTest.java",
+          "https://github.com/likethecolor/Alchemy-API/blob/ee054196b8a00fccd40e18748d9fa71aed540fef/src/test/java/com/likethecolor/alchemy/api/parser/json/TaxonomyParserTest.java",
+          "https://github.com/likethecolor/Alchemy-API/blob/ee054196b8a00fccd40e18748d9fa71aed540fef/src/test/java/com/likethecolor/alchemy/api/parser/json/TaxonomiesParserTest.java",
+          "https://github.com/likethecolor/Alchemy-API/blob/ee054196b8a00fccd40e18748d9fa71aed540fef/src/test/java/com/likethecolor/alchemy/api/parser/json/NamedEntityParserTest.java",
+          "https://github.com/likethecolor/Alchemy-API/blob/ee054196b8a00fccd40e18748d9fa71aed540fef/src/test/java/com/likethecolor/alchemy/api/entity/ResponseTest.java",
+          "https://github.com/likethecolor/Alchemy-API/blob/ee054196b8a00fccd40e18748d9fa71aed540fef/src/test/java/com/likethecolor/alchemy/api/parser/json/MicroformatParserTest.java",
+          "https://github.com/likethecolor/Alchemy-API/blob/ee054196b8a00fccd40e18748d9fa71aed540fef/src/test/java/com/likethecolor/alchemy/api/parser/json/LanguageParserTest.java",
+          "https://github.com/likethecolor/Alchemy-API/blob/ee054196b8a00fccd40e18748d9fa71aed540fef/src/test/java/com/likethecolor/alchemy/api/entity/HeaderAlchemyEntityTest.java",
+          "https://github.com/likethecolor/Alchemy-API/blob/ee054196b8a00fccd40e18748d9fa71aed540fef/src/test/java/com/likethecolor/alchemy/api/parser/json/TitleParserTest.java",
+          "https://github.com/likethecolor/Alchemy-API/blob/ee054196b8a00fccd40e18748d9fa71aed540fef/src/test/java/com/likethecolor/alchemy/api/parser/json/SentimentParserTest.java",
+          "https://github.com/likethecolor/Alchemy-API/blob/ee054196b8a00fccd40e18748d9fa71aed540fef/src/test/java/com/likethecolor/alchemy/api/parser/json/AuthorParserTest.java"
+        ]
+      },
+      {
+        "repository": "xiagu/plotlines",
+        "repoUrl": "https://github.com/xiagu/plotlines",
+        "description": "Generate a narrative chart for a well-known book or movie",
+        "language": "HTML",
+        "stargazers": 6,
+        "watchers": 6,
+        "forks": 2,
+        "subscribers": 4,
+        "sources": [
+          "https://github.com/xiagu/plotlines/blob/053f60b65e7fb95e701d71d5b61ff5efef2adf2d/data/mock.js"
+        ]
+      },
+      {
+        "repository": "zemanel/HNMood",
+        "repoUrl": "https://github.com/zemanel/HNMood",
+        "description": null,
+        "language": "Python",
+        "stargazers": 4,
+        "watchers": 4,
+        "forks": 0,
+        "subscribers": 1,
+        "sources": [
+          "https://github.com/zemanel/HNMood/blob/bd6d1f230f8a612f665e334cd653afb59bc056b2/docs/alchemy_response.js"
+        ]
+      },
+      {
+        "repository": "mollywhitnack/the-daily-feels",
+        "repoUrl": "https://github.com/mollywhitnack/the-daily-feels",
+        "description": null,
+        "language": "JavaScript",
+        "stargazers": 2,
+        "watchers": 2,
+        "forks": 2,
+        "subscribers": 4,
+        "sources": [
+          "https://github.com/mollywhitnack/the-daily-feels/blob/e5cb50c7ae82e04ab17e529584fb3ad023165c3f/src/api/mockNewsApi.js",
+          "https://github.com/mollywhitnack/the-daily-feels/blob/74eb040adddc473d278921b94fbdbb566cd17882/src/api/mockNewsApi.js"
+        ]
+      },
+      {
+        "repository": "wjohnson1000/Frontend_Personal_Project",
+        "repoUrl": "https://github.com/wjohnson1000/Frontend_Personal_Project",
+        "description": "Repo for g15 1st quarter project",
+        "language": "JavaScript",
+        "stargazers": 2,
+        "watchers": 2,
+        "forks": 0,
+        "subscribers": 2,
+        "sources": [
+          "https://github.com/wjohnson1000/Frontend_Personal_Project/blob/fd1244fae8a9932819ed287c6f53611b1acd6158/source/scripts/main.js"
+        ]
+      },
+      {
+        "repository": "Soaring-Outliers/news_graph",
+        "repoUrl": "https://github.com/Soaring-Outliers/news_graph",
+        "description": "Graph gathering news",
+        "language": "JavaScript",
+        "stargazers": 1,
+        "watchers": 1,
+        "forks": 0,
+        "subscribers": 1,
+        "sources": [
+          "https://github.com/Soaring-Outliers/news_graph/blob/ae7cde461e49b6ee8fe932fcf6c581f3a5574da4/graph/models.py"
+        ]
+      },
+      {
+        "repository": "collective/eea.alchemy",
+        "repoUrl": "https://github.com/collective/eea.alchemy",
+        "description": "Auto-discover geographical coverage, temporal coverage and keywords from documents common metadata (title, description, body, etc).",
+        "language": "Python",
+        "stargazers": 1,
+        "watchers": 1,
+        "forks": 1,
+        "subscribers": 168,
+        "sources": [
+          "https://github.com/collective/eea.alchemy/blob/6bf1ac036272423877639414d6e06fc55969d756/eea/alchemy/tests/fake.py",
+          "https://github.com/collective/eea.alchemy/blob/25a833a7fa73024ad8cc2dd239b854a702348e59/eea/alchemy/tests/fake.py"
+        ]
+      },
+      {
+        "repository": "ErikTillberg/SentimentVsStockPriceAnalyzer",
+        "repoUrl": "https://github.com/ErikTillberg/SentimentVsStockPriceAnalyzer",
+        "description": "Using Watson's text sentiment analysis to map twitter sentiment against stock prices",
+        "language": "Python",
+        "stargazers": 0,
+        "watchers": 0,
+        "forks": 0,
+        "subscribers": 2,
+        "sources": [
+          "https://github.com/ErikTillberg/SentimentVsStockPriceAnalyzer/blob/f7fbb1594bb0ecba9f983664e155c694694d759a/alchemy_sentiment.py",
+          "https://github.com/ErikTillberg/SentimentVsStockPriceAnalyzer/blob/79db784d4d5f109c6bf0e4776b4244a2dec5f8a9/alchemy_sentiment.py"
+        ]
+      },
+      {
+        "repository": "annaet/spotlight-news",
+        "repoUrl": "https://github.com/annaet/spotlight-news",
+        "description": null,
+        "language": "JavaScript",
+        "stargazers": 0,
+        "watchers": 0,
+        "forks": 0,
+        "subscribers": 4,
+        "sources": [
+          "https://github.com/annaet/spotlight-news/blob/05d43e011357ee32e87921e54bc9fbb4a4c77066/app/scripts/controllers/dendrogram.js"
+        ]
+      },
+      {
+        "repository": "adalrsjr1/www",
+        "repoUrl": "https://github.com/adalrsjr1/www",
+        "description": null,
+        "language": "PHP",
+        "stargazers": 0,
+        "watchers": 0,
+        "forks": 0,
+        "subscribers": 1,
+        "sources": [
+          "https://github.com/adalrsjr1/www/blob/eaaf400107ba0cd03c678af076e66ec1d98f8326/ccbeu.com/ccbeu-perfil/AppCore.php"
+        ]
+      }
+    ]
+  },
+  "x-apih-relationships": [
+    {
+      "relatedApiId": "ibm_watson_alchemy_language_api",
+      "commonUsages": [
+        {
+          "github_repo_name": "wjohnson1000/Frontend_Personal_Project",
+          "stargazers_count": 2
+        },
+        {
+          "github_repo_name": "wjohnson1000/wjohnson1000.github.io",
+          "stargazers_count": 0
+        },
+        { "github_repo_name": "sfaries/AlchemyNews", "stargazers_count": 0 },
+        {
+          "github_repo_name": "sickle5stone/FishyBusiness",
+          "stargazers_count": 0
+        },
+        {
+          "github_repo_name": "kongyujian/Fishackathon2016_Geospatial",
+          "stargazers_count": 0
+        },
+        {
+          "github_repo_name": "alexbtk/amos-ss16-proj9",
+          "stargazers_count": 0
+        },
+        { "github_repo_name": "Liux0047/watsonapp", "stargazers_count": 0 },
+        {
+          "github_repo_name": "ljm7b2/advSftwrEngnrTest",
+          "stargazers_count": 0
+        },
+        {
+          "github_repo_name": "cmoulika009/ASE-Lab-Assignments",
+          "stargazers_count": 0
+        },
+        {
+          "github_repo_name": "FlyMoe/Candidus-Informatio",
+          "stargazers_count": 0
+        },
+        {
+          "github_repo_name": "alexlcortes/another-test-repo",
+          "stargazers_count": 0
+        }
+      ]
+    },
+    {
+      "relatedApiId": "ibm_watson_alchemy_vision_api",
+      "commonUsages": [
+        {
+          "github_repo_name": "wjohnson1000/Frontend_Personal_Project",
+          "stargazers_count": 2
+        },
+        {
+          "github_repo_name": "wjohnson1000/wjohnson1000.github.io",
+          "stargazers_count": 0
+        },
+        { "github_repo_name": "sfaries/AlchemyNews", "stargazers_count": 0 },
+        {
+          "github_repo_name": "sickle5stone/FishyBusiness",
+          "stargazers_count": 0
+        },
+        {
+          "github_repo_name": "kongyujian/Fishackathon2016_Geospatial",
+          "stargazers_count": 0
+        },
+        {
+          "github_repo_name": "alexbtk/amos-ss16-proj9",
+          "stargazers_count": 0
+        },
+        { "github_repo_name": "Liux0047/watsonapp", "stargazers_count": 0 },
+        {
+          "github_repo_name": "ljm7b2/advSftwrEngnrTest",
+          "stargazers_count": 0
+        },
+        {
+          "github_repo_name": "cmoulika009/ASE-Lab-Assignments",
+          "stargazers_count": 0
+        },
+        {
+          "github_repo_name": "FlyMoe/Candidus-Informatio",
+          "stargazers_count": 0
+        },
+        {
+          "github_repo_name": "alexlcortes/another-test-repo",
+          "stargazers_count": 0
+        }
+      ]
+    },
+    {
+      "relatedApiId": "yahoo_weather_api",
+      "commonUsages": [
+        {
+          "github_repo_name": "sickle5stone/FishyBusiness",
+          "stargazers_count": 0
+        },
+        {
+          "github_repo_name": "kongyujian/Fishackathon2016_Geospatial",
+          "stargazers_count": 0
+        }
+      ]
+    },
+    {
+      "relatedApiId": "google_civic_info_api",
+      "commonUsages": [
+        {
+          "github_repo_name": "FlyMoe/Candidus-Informatio",
+          "stargazers_count": 0
+        },
+        {
+          "github_repo_name": "alexlcortes/another-test-repo",
+          "stargazers_count": 0
+        }
+      ]
+    },
+    {
+      "relatedApiId": "google_civicinfo_api",
+      "commonUsages": [
+        {
+          "github_repo_name": "FlyMoe/Candidus-Informatio",
+          "stargazers_count": 0
+        },
+        {
+          "github_repo_name": "alexlcortes/another-test-repo",
+          "stargazers_count": 0
+        }
+      ]
+    },
+    {
+      "relatedApiId": "google_blogger_api",
+      "commonUsages": [
+        {
+          "github_repo_name": "atrijitdasgupta/streetbuzz-investor",
+          "stargazers_count": 0
+        }
+      ]
+    },
+    {
+      "relatedApiId": "amazon_product_advertising_api",
+      "commonUsages": [
+        {
+          "github_repo_name": "atrijitdasgupta/streetbuzz-investor",
+          "stargazers_count": 0
+        }
+      ]
+    },
+    {
+      "relatedApiId": "quizlet_api_v2",
+      "commonUsages": [
+        { "github_repo_name": "jaxball/hackthenorth16", "stargazers_count": 0 }
+      ]
+    }
+  ],
+  "x-apih-sdks": [
+    {
+      "name": "rest-api-client",
+      "downloads": { "last-day": 0, "last-month": 100, "last-week": 26 },
+      "description": "Simple REST client built on the request module",
+      "url": "https://www.npmjs.com/package/rest-api-client",
+      "repoUrl": "https://github.com/ryanlelek/rest-api-client",
+      "language": "JavaScript"
+    },
+    {
+      "language": "JavaScript",
+      "description": "Node.js REST API client for Parse.com",
+      "url": "https://www.npmjs.com/package/parse-rest-api",
+      "name": "parse-rest-api",
+      "downloads": { "last-day": 0, "last-month": 21, "last-week": 3 }
+    },
+    {
+      "name": "json-rest-api",
+      "downloads": { "last-day": 0, "last-month": 106, "last-week": 16 },
+      "description": "A simple lightweight REST API that receives and responds to JSON HTTP requests, supports all verbs. Very simple.",
+      "url": "https://www.npmjs.com/package/json-rest-api",
+      "repoUrl": "git://github.com/stdarg/json-rest-api",
+      "language": "JavaScript"
+    },
+    {
+      "name": "pimatic-rest-api",
+      "downloads": { "last-day": 0, "last-month": 120, "last-week": 16 },
+      "description": "Provides a rest-api for the webinterface.",
+      "url": "https://www.npmjs.com/package/pimatic-rest-api",
+      "repoUrl": "git://github.com/pimatic/pimatic-rest-api",
+      "language": "JavaScript"
+    },
+    {
+      "name": "keystone-rest-api",
+      "downloads": { "last-day": 1, "last-month": 58, "last-week": 10 },
+      "description": "Creates a powerful Rest API based on Keystone Lists",
+      "url": "https://www.npmjs.com/package/keystone-rest-api",
+      "repoUrl": "git+https://github.com/sarriaroman/Keystone-Rest-API",
+      "language": "JavaScript",
+      "license": "ISC"
+    },
+    {
+      "name": "sails-hook-cti-rest-api-responses",
+      "downloads": { "last-day": 0, "last-month": 26, "last-week": 6 },
+      "description": "REST friendly api responses for sails",
+      "url": "https://www.npmjs.com/package/sails-hook-cti-rest-api-responses",
+      "repoUrl": "git+https://github.com/CanTireInnovations/sails-hook-cti-rest-api-responses",
+      "language": "JavaScript",
+      "license": "ISC"
+    },
+    {
+      "name": "ember-cli-rest-api-blueprint",
+      "downloads": { "last-day": 2, "last-month": 274, "last-week": 59 },
+      "description": "Ember CLI blueprint addon for a DS.RESTAdapter compatible REST API",
+      "url": "https://www.npmjs.com/package/ember-cli-rest-api-blueprint",
+      "repoUrl": "git://github.com/manuelmitasch/ember-cli-rest-api-blueprint",
+      "language": "JavaScript",
+      "license": "MIT"
+    },
+    {
+      "name": "pulsar-rest-api-client-node",
+      "downloads": { "last-day": 0, "last-month": 97, "last-week": 10 },
+      "description": "pulsar-rest-api-client-node [![Build Status](https://travis-ci.org/cargomedia/pulsar-rest-api-client-node.svg?branch=master)](https://travis-ci.org/cargomedia/pulsar-rest-api-client-node) ===========================",
+      "url": "https://www.npmjs.com/package/pulsar-rest-api-client-node",
+      "repoUrl": "git+ssh://git@github.com/cargomedia/pulsar-rest-api-client-node",
+      "language": "JavaScript",
+      "license": "MIT"
+    },
+    {
+      "name": "pulsar-rest-api",
+      "downloads": { "last-day": 0, "last-month": 160, "last-week": 22 },
+      "description": "REST API for executing Pulsar tasks.",
+      "url": "https://www.npmjs.com/package/pulsar-rest-api",
+      "repoUrl": "git+ssh://git@github.com/cargomedia/pulsar-rest-api",
+      "language": "JavaScript",
+      "license": "MIT"
+    },
+    {
+      "name": "git-rest-api",
+      "downloads": { "last-day": 1, "last-month": 137, "last-week": 27 },
+      "description": "A library providing a restful Git API mimicking as most as possible the old good git",
+      "url": "https://www.npmjs.com/package/git-rest-api",
+      "repoUrl": "https://github.com/korya/node-git-rest-api",
+      "language": "JavaScript"
+    }
+  ],
+  "x-apih-organization": "public",
+  "meta": { "revision": 0, "created": 1495048571337, "version": 0 },
+  "$loki": 479
+}

--- a/test/instagram_swagger.json
+++ b/test/instagram_swagger.json
@@ -1,9 +1,6 @@
-
 {
   "swagger": "2.0",
-  "schemes": [
-    "https"
-  ],
+  "schemes": ["https"],
   "host": "api.instagram.com",
   "basePath": "/v1",
   "info": {
@@ -31,9 +28,7 @@
     "description": "Instagram Developer Documentation",
     "url": "https://instagram.com/developer"
   },
-  "produces": [
-    "application/json"
-  ],
+  "produces": ["application/json"],
   "securityDefinitions": {
     "api_key": {
       "in": "query",
@@ -130,15 +125,11 @@
             "api_key": []
           },
           {
-            "instagram_auth": [
-              "basic"
-            ]
+            "instagram_auth": ["basic"]
           }
         ],
         "summary": "Get recent media from a custom geo-id.",
-        "tags": [
-          "geographies"
-        ]
+        "tags": ["geographies"]
       }
     },
     "/locations/search": {
@@ -204,15 +195,11 @@
             "api_key": []
           },
           {
-            "instagram_auth": [
-              "public_content"
-            ]
+            "instagram_auth": ["public_content"]
           }
         ],
         "summary": "Search for a location by geographic coordinate.",
-        "tags": [
-          "locations"
-        ]
+        "tags": ["locations"]
       }
     },
     "/locations/{location-id}": {
@@ -240,15 +227,11 @@
             "api_key": []
           },
           {
-            "instagram_auth": [
-              "public_content"
-            ]
+            "instagram_auth": ["public_content"]
           }
         ],
         "summary": "Get information about a location.",
-        "tags": [
-          "locations"
-        ]
+        "tags": ["locations"]
       }
     },
     "/locations/{location-id}/media/recent": {
@@ -306,15 +289,11 @@
             "api_key": []
           },
           {
-            "instagram_auth": [
-              "public_content"
-            ]
+            "instagram_auth": ["public_content"]
           }
         ],
         "summary": "Get a list of recent media objects from a given location.",
-        "tags": [
-          "locations"
-        ]
+        "tags": ["locations"]
       }
     },
     "/media/popular": {
@@ -334,15 +313,11 @@
             "api_key": []
           },
           {
-            "instagram_auth": [
-              "basic"
-            ]
+            "instagram_auth": ["basic"]
           }
         ],
         "summary": "Get a list of currently popular media.",
-        "tags": [
-          "media"
-        ]
+        "tags": ["media"]
       }
     },
     "/media/search": {
@@ -403,15 +378,11 @@
             "api_key": []
           },
           {
-            "instagram_auth": [
-              "public_content"
-            ]
+            "instagram_auth": ["public_content"]
           }
         ],
         "summary": "Search for media in a given area.",
-        "tags": [
-          "media"
-        ]
+        "tags": ["media"]
       }
     },
     "/media/shortcode/{shortcode}": {
@@ -439,16 +410,11 @@
             "api_key": []
           },
           {
-            "instagram_auth": [
-              "basic",
-              "public_content"
-            ]
+            "instagram_auth": ["basic", "public_content"]
           }
         ],
         "summary": "Get information about a media object.",
-        "tags": [
-          "media"
-        ]
+        "tags": ["media"]
       }
     },
     "/media/{media-id}": {
@@ -476,16 +442,11 @@
             "api_key": []
           },
           {
-            "instagram_auth": [
-              "basic",
-              "public_content"
-            ]
+            "instagram_auth": ["basic", "public_content"]
           }
         ],
         "summary": "Get information about a media object.",
-        "tags": [
-          "media"
-        ]
+        "tags": ["media"]
       }
     },
     "/media/{media-id}/comments": {
@@ -513,16 +474,11 @@
             "api_key": []
           },
           {
-            "instagram_auth": [
-              "basic",
-              "public_content"
-            ]
+            "instagram_auth": ["basic", "public_content"]
           }
         ],
         "summary": "Get a list of recent comments on a media object.",
-        "tags": [
-          "comments"
-        ]
+        "tags": ["comments"]
       },
       "post": {
         "description": "Create a comment on a media object with the following rules:\n\n  * The total length of the comment cannot exceed 300 characters.\n  * The comment cannot contain more than 4 hashtags.\n  * The comment cannot contain more than 1 URL.\n  * The comment cannot consist of all capital letters.\n",
@@ -555,15 +511,11 @@
             "api_key": []
           },
           {
-            "instagram_auth": [
-              "comments"
-            ]
+            "instagram_auth": ["comments"]
           }
         ],
         "summary": "Create a comment on a media object.",
-        "tags": [
-          "comments"
-        ]
+        "tags": ["comments"]
       }
     },
     "/media/{media-id}/comments/{comment-id}": {
@@ -598,15 +550,11 @@
             "api_key": []
           },
           {
-            "instagram_auth": [
-              "comments"
-            ]
+            "instagram_auth": ["comments"]
           }
         ],
         "summary": "Remove a comment.",
-        "tags": [
-          "comments"
-        ]
+        "tags": ["comments"]
       }
     },
     "/media/{media-id}/likes": {
@@ -634,15 +582,11 @@
             "api_key": []
           },
           {
-            "instagram_auth": [
-              "likes"
-            ]
+            "instagram_auth": ["likes"]
           }
         ],
         "summary": "Remove a like on this media by the current user.",
-        "tags": [
-          "likes"
-        ]
+        "tags": ["likes"]
       },
       "get": {
         "description": "Get a list of users who have liked this media.",
@@ -668,16 +612,11 @@
             "api_key": []
           },
           {
-            "instagram_auth": [
-              "basic",
-              "public_content"
-            ]
+            "instagram_auth": ["basic", "public_content"]
           }
         ],
         "summary": "Get a list of users who have liked this media.",
-        "tags": [
-          "likes"
-        ]
+        "tags": ["likes"]
       },
       "post": {
         "description": "Set a like on this media by the currently authenticated user.",
@@ -703,15 +642,11 @@
             "api_key": []
           },
           {
-            "instagram_auth": [
-              "likes"
-            ]
+            "instagram_auth": ["likes"]
           }
         ],
         "summary": "Set a like on this media by the current user.",
-        "tags": [
-          "likes"
-        ]
+        "tags": ["likes"]
       }
     },
     "/tags/search": {
@@ -739,15 +674,11 @@
             "api_key": []
           },
           {
-            "instagram_auth": [
-              "public_content"
-            ]
+            "instagram_auth": ["public_content"]
           }
         ],
         "summary": "Search for tags by name.",
-        "tags": [
-          "tags"
-        ]
+        "tags": ["tags"]
       }
     },
     "/tags/{tag-name}": {
@@ -775,15 +706,11 @@
             "api_key": []
           },
           {
-            "instagram_auth": [
-              "public_content"
-            ]
+            "instagram_auth": ["public_content"]
           }
         ],
         "summary": "Get information about a tag object.",
-        "tags": [
-          "tags"
-        ]
+        "tags": ["tags"]
       }
     },
     "/tags/{tag-name}/media/recent": {
@@ -832,15 +759,11 @@
             "api_key": []
           },
           {
-            "instagram_auth": [
-              "public_content"
-            ]
+            "instagram_auth": ["public_content"]
           }
         ],
         "summary": "Get a list of recently tagged media.",
-        "tags": [
-          "tags"
-        ]
+        "tags": ["tags"]
       }
     },
     "/users/search": {
@@ -875,15 +798,11 @@
             "api_key": []
           },
           {
-            "instagram_auth": [
-              "basic"
-            ]
+            "instagram_auth": ["basic"]
           }
         ],
         "summary": "Search for a user by name.",
-        "tags": [
-          "users"
-        ]
+        "tags": ["users"]
       }
     },
     "/users/self/feed": {
@@ -926,15 +845,11 @@
             "api_key": []
           },
           {
-            "instagram_auth": [
-              "basic"
-            ]
+            "instagram_auth": ["basic"]
           }
         ],
         "summary": "See the authenticated user's feed.",
-        "tags": [
-          "users"
-        ]
+        "tags": ["users"]
       }
     },
     "/users/self/media/liked": {
@@ -969,15 +884,11 @@
             "api_key": []
           },
           {
-            "instagram_auth": [
-              "basic"
-            ]
+            "instagram_auth": ["basic"]
           }
         ],
         "summary": "See the list of media liked by the authenticated user.",
-        "tags": [
-          "users"
-        ]
+        "tags": ["users"]
       }
     },
     "/users/self/requested-by": {
@@ -996,15 +907,11 @@
             "api_key": []
           },
           {
-            "instagram_auth": [
-              "follower_list"
-            ]
+            "instagram_auth": ["follower_list"]
           }
         ],
         "summary": "List the users who have requested this user's permission to follow.",
-        "tags": [
-          "relationships"
-        ]
+        "tags": ["relationships"]
       }
     },
     "/users/{user-id}": {
@@ -1035,16 +942,11 @@
             "api_key": []
           },
           {
-            "instagram_auth": [
-              "basic",
-              "public_content"
-            ]
+            "instagram_auth": ["basic", "public_content"]
           }
         ],
         "summary": "Get basic information about a user.",
-        "tags": [
-          "users"
-        ]
+        "tags": ["users"]
       }
     },
     "/users/{user-id}/followed-by": {
@@ -1072,15 +974,11 @@
             "api_key": []
           },
           {
-            "instagram_auth": [
-              "follower_list"
-            ]
+            "instagram_auth": ["follower_list"]
           }
         ],
         "summary": "Get the list of users this user is followed by.",
-        "tags": [
-          "relationships"
-        ]
+        "tags": ["relationships"]
       }
     },
     "/users/{user-id}/follows": {
@@ -1108,15 +1006,11 @@
             "api_key": []
           },
           {
-            "instagram_auth": [
-              "follower_list"
-            ]
+            "instagram_auth": ["follower_list"]
           }
         ],
         "summary": "Get the list of users this user follows.",
-        "tags": [
-          "relationships"
-        ]
+        "tags": ["relationships"]
       }
     },
     "/users/{user-id}/media/recent": {
@@ -1181,16 +1075,11 @@
             "api_key": []
           },
           {
-            "instagram_auth": [
-              "basic",
-              "public_content"
-            ]
+            "instagram_auth": ["basic", "public_content"]
           }
         ],
         "summary": "Get the most recent media published by a user.",
-        "tags": [
-          "users"
-        ]
+        "tags": ["users"]
       }
     },
     "/users/{user-id}/relationship": {
@@ -1218,15 +1107,11 @@
             "api_key": []
           },
           {
-            "instagram_auth": [
-              "follower_list"
-            ]
+            "instagram_auth": ["follower_list"]
           }
         ],
         "summary": "Get information about a relationship to another user.",
-        "tags": [
-          "relationships"
-        ]
+        "tags": ["relationships"]
       },
       "post": {
         "description": "Modify the relationship between the current user and the target user.",
@@ -1267,15 +1152,11 @@
             "api_key": []
           },
           {
-            "instagram_auth": [
-              "relationships"
-            ]
+            "instagram_auth": ["relationships"]
           }
         ],
         "summary": "Modify the relationship between the current user and the target user.",
-        "tags": [
-          "relationships"
-        ]
+        "tags": ["relationships"]
       }
     }
   },
@@ -1533,10 +1414,7 @@
         },
         "type": {
           "description": "Type of this media entry",
-          "enum": [
-            "image",
-            "video"
-          ],
+          "enum": ["image", "video"],
           "type": "string"
         },
         "user": {
@@ -1639,20 +1517,12 @@
       "properties": {
         "incoming_status": {
           "description": "Status of incoming relationship",
-          "enum": [
-            "none",
-            "followed_by",
-            "requested_by"
-          ],
+          "enum": ["none", "followed_by", "requested_by"],
           "type": "string"
         },
         "outgoing_status": {
           "description": "Status of outgoing relationship",
-          "enum": [
-            "none",
-            "follows",
-            "requested"
-          ],
+          "enum": ["none", "follows", "requested"],
           "type": "string"
         },
         "target_user_is_private": {
@@ -1692,11 +1562,7 @@
       "properties": {
         "outgoing_status": {
           "description": "Status of outgoing relationship",
-          "enum": [
-            "none",
-            "follows",
-            "requested"
-          ],
+          "enum": ["none", "follows", "requested"],
           "type": "string"
         }
       },

--- a/test/parameter_example_swagger.json
+++ b/test/parameter_example_swagger.json
@@ -22,16 +22,33 @@
   ],
   "paths": {
     "/pets": {
-      "post": {
-        "description": "Creates a new pet in the store.  Duplicates are allowed",
-        "operationId": "addPet",
+      "get": {
+        "description": "Get Pets from store",
+        "operationId": "getPet",
         "parameters": [
           {
+            "name": "tags",
             "in": "query",
-            "name": "pet",
-            "description": "Pet to add to the store",
+            "description": "tags to filter by",
+            "required": false,
+            "style": "form",
+            "example": ["dog", "cat"],
             "schema": {
-              "$ref": "#/components/schemas/NewPet"
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "maximum number of results to return",
+            "example": 10,
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
             }
           }
         ],
@@ -62,6 +79,22 @@
   },
   "components": {
     "schemas": {
+      "Pet": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/NewPet"
+          },
+          {
+            "required": ["id"],
+            "properties": {
+              "id": {
+                "type": "integer",
+                "format": "int64"
+              }
+            }
+          }
+        ]
+      },
       "NewPet": {
         "required": ["name"],
         "properties": {
@@ -69,6 +102,18 @@
             "type": "string"
           },
           "tag": {
+            "type": "string"
+          }
+        }
+      },
+      "Error": {
+        "required": ["code", "message"],
+        "properties": {
+          "code": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "message": {
             "type": "string"
           }
         }

--- a/test/petstore_oas.json
+++ b/test/petstore_oas.json
@@ -1,239 +1,242 @@
 {
-	"openapi": "3.0.0",
-	"info": {
-		"version": "1.0.0",
-		"title": "Swagger Petstore",
-		"description": "A sample API that uses a petstore as an example to demonstrate features in the OpenAPI 3.0 specification",
-		"termsOfService": "http://swagger.io/terms/",
-		"contact": {
-			"name": "Swagger API Team",
-			"email": "apiteam@swagger.io",
-			"url": "http://swagger.io"
-		},
-		"license": {
-			"name": "Apache 2.0",
-			"url": "https://www.apache.org/licenses/LICENSE-2.0.html"
-		}
-	},
-	"servers": [
-		{
-			"url": "http://petstore.swagger.io/api"
-		}
-	],
-	"paths": {
-		"/pets": {
-			"get": {
-				"description": "Returns all pets from the system that the user has access to\nNam sed condimentum est. Maecenas tempor sagittis sapien, nec rhoncus sem sagittis sit amet. Aenean at gravida augue, ac iaculis sem. Curabitur odio lorem, ornare eget elementum nec, cursus id lectus. Duis mi turpis, pulvinar ac eros ac, tincidunt varius justo. In hac habitasse platea dictumst. Integer at adipiscing ante, a sagittis ligula. Aenean pharetra tempor ante molestie imperdiet. Vivamus id aliquam diam. Cras quis velit non tortor eleifend sagittis. Praesent at enim pharetra urna volutpat venenatis eget eget mauris. In eleifend fermentum facilisis. Praesent enim enim, gravida ac sodales sed, placerat id erat. Suspendisse lacus dolor, consectetur non augue vel, vehicula interdum libero. Morbi euismod sagittis libero sed lacinia.\n\nSed tempus felis lobortis leo pulvinar rutrum. Nam mattis velit nisl, eu condimentum ligula luctus nec. Phasellus semper velit eget aliquet faucibus. In a mattis elit. Phasellus vel urna viverra, condimentum lorem id, rhoncus nibh. Ut pellentesque posuere elementum. Sed a varius odio. Morbi rhoncus ligula libero, vel eleifend nunc tristique vitae. Fusce et sem dui. Aenean nec scelerisque tortor. Fusce malesuada accumsan magna vel tempus. Quisque mollis felis eu dolor tristique, sit amet auctor felis gravida. Sed libero lorem, molestie sed nisl in, accumsan tempor nisi. Fusce sollicitudin massa ut lacinia mattis. Sed vel eleifend lorem. Pellentesque vitae felis pretium, pulvinar elit eu, euismod sapien.\n",
-				"operationId": "findPets",
-				"parameters": [
-					{
-						"name": "tags",
-						"in": "query",
-						"description": "tags to filter by",
-						"required": false,
-						"style": "form",
-						"schema": {
-							"type": "array",
-							"items": {
-								"type": "string"
-							}
-						}
-					},
-					{
-						"name": "limit",
-						"in": "query",
-						"description": "maximum number of results to return",
-						"required": false,
-						"schema": {
-							"type": "integer",
-							"format": "int32"
-						}
-					}
-				],
-				"responses": {
-					"200": {
-						"description": "pet response",
-						"content": {
-							"application/json": {
-								"schema": {
-									"type": "array",
-									"items": {
-										"$ref": "#/components/schemas/Pet"
-									}
-								}
-							}
-						}
-					},
-					"default": {
-						"description": "unexpected error",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/Error"
-								}
-							}
-						}
-					}
-				}
-			},
-			"post": {
-				"description": "Creates a new pet in the store.  Duplicates are allowed",
-				"operationId": "addPet",
-				"requestBody": {
-					"description": "Pet to add to the store",
-					"required": true,
-					"content": {
-						"application/json": {
-							"schema": {
-								"$ref": "#/components/schemas/NewPet"
-							}
-						}
-					}
-				},
-				"responses": {
-					"200": {
-						"description": "pet response",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/Pet"
-								}
-							}
-						}
-					},
-					"default": {
-						"description": "unexpected error",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/Error"
-								}
-							}
-						}
-					}
-				}
-			}
-		},
-		"/pets/{id}": {
-			"get": {
-				"description": "Returns a user based on a single ID, if the user does not have access to the pet",
-				"operationId": "find pet by id",
-				"parameters": [
-					{
-						"name": "id",
-						"in": "path",
-						"description": "ID of pet to fetch",
-						"required": true,
-						"schema": {
-							"type": "integer",
-							"format": "int64"
-						}
-					}
-				],
-				"responses": {
-					"200": {
-						"description": "pet response",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/Pet"
-								}
-							}
-						}
-					},
-					"default": {
-						"description": "unexpected error",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/Error"
-								}
-							}
-						}
-					}
-				}
-			},
-			"delete": {
-				"description": "deletes a single pet based on the ID supplied",
-				"operationId": "deletePet",
-				"parameters": [
-					{
-						"name": "id",
-						"in": "path",
-						"description": "ID of pet to delete",
-						"required": true,
-						"schema": {
-							"type": "integer",
-							"format": "int64"
-						}
-					}
-				],
-				"responses": {
-					"204": {
-						"description": "pet deleted"
-					},
-					"default": {
-						"description": "unexpected error",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/Error"
-								}
-							}
-						}
-					}
-				}
-			}
-		}
-	},
-	"components": {
-		"schemas": {
-			"Pet": {
-				"allOf": [
-					{
-						"$ref": "#/components/schemas/NewPet"
-					},
-					{
-						"required": [
-							"id"
-						],
-						"properties": {
-							"id": {
-								"type": "integer",
-								"format": "int64"
-							}
-						}
-					}
-				]
-			},
-			"NewPet": {
-				"required": [
-					"name"
-				],
-				"properties": {
-					"name": {
-						"type": "string"
-					},
-					"tag": {
-						"type": "string"
-					}
-				}
-			},
-			"Error": {
-				"required": [
-					"code",
-					"message"
-				],
-				"properties": {
-					"code": {
-						"type": "integer",
-						"format": "int32"
-					},
-					"message": {
-						"type": "string"
-					}
-				}
-			}
-		}
-	}
+  "openapi": "3.0.0",
+  "info": {
+    "version": "1.0.0",
+    "title": "Swagger Petstore",
+    "description": "A sample API that uses a petstore as an example to demonstrate features in the OpenAPI 3.0 specification",
+    "termsOfService": "http://swagger.io/terms/",
+    "contact": {
+      "name": "Swagger API Team",
+      "email": "apiteam@swagger.io",
+      "url": "http://swagger.io"
+    },
+    "license": {
+      "name": "Apache 2.0",
+      "url": "https://www.apache.org/licenses/LICENSE-2.0.html"
+    }
+  },
+  "servers": [
+    {
+      "url": "http://petstore.swagger.io/api"
+    }
+  ],
+  "paths": {
+    "/pets": {
+      "servers": [
+        {
+          "url": "https://path-override.example.com"
+        }
+      ],
+      "get": {
+        "servers": [
+          {
+            "url": "https://method-override.example.com"
+          }
+        ],
+        "description": "Returns all pets from the system that the user has access to\nNam sed condimentum est. Maecenas tempor sagittis sapien, nec rhoncus sem sagittis sit amet. Aenean at gravida augue, ac iaculis sem. Curabitur odio lorem, ornare eget elementum nec, cursus id lectus. Duis mi turpis, pulvinar ac eros ac, tincidunt varius justo. In hac habitasse platea dictumst. Integer at adipiscing ante, a sagittis ligula. Aenean pharetra tempor ante molestie imperdiet. Vivamus id aliquam diam. Cras quis velit non tortor eleifend sagittis. Praesent at enim pharetra urna volutpat venenatis eget eget mauris. In eleifend fermentum facilisis. Praesent enim enim, gravida ac sodales sed, placerat id erat. Suspendisse lacus dolor, consectetur non augue vel, vehicula interdum libero. Morbi euismod sagittis libero sed lacinia.\n\nSed tempus felis lobortis leo pulvinar rutrum. Nam mattis velit nisl, eu condimentum ligula luctus nec. Phasellus semper velit eget aliquet faucibus. In a mattis elit. Phasellus vel urna viverra, condimentum lorem id, rhoncus nibh. Ut pellentesque posuere elementum. Sed a varius odio. Morbi rhoncus ligula libero, vel eleifend nunc tristique vitae. Fusce et sem dui. Aenean nec scelerisque tortor. Fusce malesuada accumsan magna vel tempus. Quisque mollis felis eu dolor tristique, sit amet auctor felis gravida. Sed libero lorem, molestie sed nisl in, accumsan tempor nisi. Fusce sollicitudin massa ut lacinia mattis. Sed vel eleifend lorem. Pellentesque vitae felis pretium, pulvinar elit eu, euismod sapien.\n",
+        "operationId": "findPets",
+        "parameters": [
+          {
+            "name": "tags",
+            "in": "query",
+            "description": "tags to filter by",
+            "required": false,
+            "style": "form",
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "maximum number of results to return",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "pet response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Pet"
+                  }
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "unexpected error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "description": "Creates a new pet in the store.  Duplicates are allowed",
+        "operationId": "addPet",
+        "requestBody": {
+          "description": "Pet to add to the store",
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/NewPet"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "pet response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Pet"
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "unexpected error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/pets/{id}": {
+      "get": {
+        "description": "Returns a user based on a single ID, if the user does not have access to the pet",
+        "operationId": "find pet by id",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "ID of pet to fetch",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "pet response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Pet"
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "unexpected error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "description": "deletes a single pet based on the ID supplied",
+        "operationId": "deletePet",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "ID of pet to delete",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "pet deleted"
+          },
+          "default": {
+            "description": "unexpected error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "Pet": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/NewPet"
+          },
+          {
+            "required": ["id"],
+            "properties": {
+              "id": {
+                "type": "integer",
+                "format": "int64"
+              }
+            }
+          }
+        ]
+      },
+      "NewPet": {
+        "required": ["name"],
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "tag": {
+            "type": "string"
+          }
+        }
+      },
+      "Error": {
+        "required": ["code", "message"],
+        "properties": {
+          "code": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "message": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  }
 }

--- a/test/petstore_swagger.json
+++ b/test/petstore_swagger.json
@@ -1,1225 +1,1062 @@
 {
-	"swagger": "2.0",
-	"schemes": [
-		"http",
-		"https"
-	],
-	"host": "petstore.swagger.io",
-	"basePath": "/v2",
-	"info": {
-		"description": "This is a sample server Petstore server.\nYou can find out more about Swagger at\n[http://swagger.io](http://swagger.io) or on [irc.freenode.net, #swagger](http://swagger.io/irc/).\nFor this sample, you can use the api key `special-key` to test the authorization filters.\n# Introduction\nThis API is documented in **OpenAPI format** and is based on\n[Petstore sample](http://petstore.swagger.io/) provided by [swagger.io](http://swagger.io) team.\nIt was **extended** to illustrate features of [generator-openapi-repo](https://github.com/Rebilly/generator-openapi-repo)\ntool and [ReDoc](https://github.com/Rebilly/ReDoc) documentation. In addition to standard\nOpenAPI syntax we use a few [vendor extensions](https://github.com/Rebilly/ReDoc/blob/master/docs/redoc-vendor-extensions.md).\n# OpenAPI Specification\nThis API is documented in **OpenAPI format** and is based on\n[Petstore sample](http://petstore.swagger.io/) provided by [swagger.io](http://swagger.io) team.\nIt was **extended** to illustrate features of [generator-openapi-repo](https://github.com/Rebilly/generator-openapi-repo)\ntool and [ReDoc](https://github.com/Rebilly/ReDoc) documentation. In addition to standard\nOpenAPI syntax we use a few [vendor extensions](https://github.com/Rebilly/ReDoc/blob/master/docs/redoc-vendor-extensions.md).\n# Cross-Origin Resource Sharing\nThis API features Cross-Origin Resource Sharing (CORS) implemented in compliance with  [W3C spec](https://www.w3.org/TR/cors/).\nAnd that allows cross-domain communication from the browser.\nAll responses have a wildcard same-origin which makes them completely public and accessible to everyone, including any code on any site.\n# Authentication\nPetstore offers two forms of authentication:\n  - API Key\n  - OAuth2\n\nOAuth2 - an open protocol to allow secure authorization in a simple\nand standard method from web, mobile and desktop applications.\n<!-- ReDoc-Inject: <security-definitions> -->\n",
-		"version": "1.0.0",
-		"title": "Swagger Petstore",
-		"termsOfService": "http://swagger.io/terms/",
-		"contact": {
-			"email": "apiteam@swagger.io",
-			"url": "https://github.com/Rebilly/ReDoc"
-		},
-		"x-logo": {
-			"url": "https://rebilly.github.io/ReDoc/petstore-logo.png"
-		},
-		"license": {
-			"name": "Apache 2.0",
-			"url": "http://www.apache.org/licenses/LICENSE-2.0.html"
-		}
-	},
-	"externalDocs": {
-		"description": "Find out how to create Github repo for your OpenAPI spec.",
-		"url": "https://github.com/Rebilly/generator-openapi-repo"
-	},
-	"tags": [
-		{
-			"name": "pet",
-			"description": "Everything about your Pets"
-		},
-		{
-			"name": "store",
-			"description": "Access to Petstore orders"
-		},
-		{
-			"name": "user",
-			"description": "Operations about user"
-		}
-	],
-	"x-tagGroups": [
-		{
-			"name": "General",
-			"tags": [
-				"pet",
-				"store"
-			]
-		},
-		{
-			"name": "User Management",
-			"tags": [
-				"user"
-			]
-		}
-	],
-	"securityDefinitions": {
-		"petstore_auth": {
-			"description": "Get access to data while protecting your account credentials.\nOAuth2 is also a safer and more secure way to give you access.\n",
-			"type": "oauth2",
-			"authorizationUrl": "http://petstore.swagger.io/api/oauth/dialog",
-			"flow": "implicit",
-			"scopes": {
-				"write:pets": "modify pets in your account",
-				"read:pets": "read your pets"
-			}
-		},
-		"api_key": {
-			"description": "For this sample, you can use the api key `special-key` to test the authorization filters.\n",
-			"type": "apiKey",
-			"name": "api_key",
-			"in": "header"
-		}
-	},
-	"x-servers": [
-		{
-			"url": "//petstore.swagger.io/v2",
-			"description": "Default server"
-		},
-		{
-			"url": "//petstore.swagger.io/sandbox",
-			"description": "Sandbox server"
-		}
-	],
-	"paths": {
-		"/pet": {
-			"post": {
-				"tags": [
-					"pet"
-				],
-				"summary": "Add a new pet to the store",
-				"description": "Add new pet to the store inventory.",
-				"operationId": "addPet",
-				"consumes": [
-					"application/json",
-					"application/xml"
-				],
-				"produces": [
-					"application/xml",
-					"application/json"
-				],
-				"parameters": [
-					{
-						"in": "body",
-						"name": "body",
-						"description": "Pet object that needs to be added to the store",
-						"required": true,
-						"schema": {
-							"$ref": "#/definitions/Pet"
-						}
-					}
-				],
-				"responses": {
-					"405": {
-						"description": "Invalid input"
-					}
-				},
-				"security": [
-					{
-						"petstore_auth": [
-							"write:pets",
-							"read:pets"
-						]
-					}
-				],
-				"x-code-samples": [
-					{
-						"lang": "C#",
-						"source": "PetStore.v1.Pet pet = new PetStore.v1.Pet();\npet.setApiKey(\"your api key\");\npet.petType = PetStore.v1.Pet.TYPE_DOG;\npet.name = \"Rex\";\n// set other fields\nPetStoreResponse response = pet.create();\nif (response.statusCode == HttpStatusCode.Created)\n{\n  // Successfully created\n}\nelse\n{\n  // Something wrong -- check response for errors\n  Console.WriteLine(response.getRawResponse());\n}\n"
-					},
-					{
-						"lang": "PHP",
-						"source": "$form = new \\PetStore\\Entities\\Pet();\n$form->setPetType(\"Dog\");\n$form->setName(\"Rex\");\n// set other fields\ntry {\n    $pet = $client->pets()->create($form);\n} catch (UnprocessableEntityException $e) {\n    var_dump($e->getErrors());\n}\n"
-					}
-				]
-			},
-			"put": {
-				"tags": [
-					"pet"
-				],
-				"summary": "Update an existing pet",
-				"description": "",
-				"operationId": "updatePet",
-				"consumes": [
-					"application/json",
-					"application/xml"
-				],
-				"produces": [
-					"application/xml",
-					"application/json"
-				],
-				"parameters": [
-					{
-						"in": "body",
-						"name": "body",
-						"description": "Pet object that needs to be added to the store",
-						"required": true,
-						"schema": {
-							"$ref": "#/definitions/Pet"
-						}
-					}
-				],
-				"responses": {
-					"400": {
-						"description": "Invalid ID supplied"
-					},
-					"404": {
-						"description": "Pet not found"
-					},
-					"405": {
-						"description": "Validation exception"
-					}
-				},
-				"security": [
-					{
-						"petstore_auth": [
-							"write:pets",
-							"read:pets"
-						]
-					}
-				],
-				"x-code-samples": [
-					{
-						"lang": "PHP",
-						"source": "$form = new \\PetStore\\Entities\\Pet();\n$form->setPetId(1);\n$form->setPetType(\"Dog\");\n$form->setName(\"Rex\");\n// set other fields\ntry {\n    $pet = $client->pets()->update($form);\n} catch (UnprocessableEntityException $e) {\n    var_dump($e->getErrors());\n}\n"
-					}
-				]
-			}
-		},
-		"/pet/{petId}": {
-			"get": {
-				"tags": [
-					"pet"
-				],
-				"summary": "Find pet by ID",
-				"description": "Returns a single pet",
-				"operationId": "getPetById",
-				"produces": [
-					"application/xml",
-					"application/json"
-				],
-				"parameters": [
-					{
-						"name": "petId",
-						"in": "path",
-						"description": "ID of pet to return",
-						"required": true,
-						"type": "integer",
-						"format": "int64"
-					}
-				],
-				"responses": {
-					"200": {
-						"description": "successful operation",
-						"schema": {
-							"$ref": "#/definitions/Pet"
-						}
-					},
-					"400": {
-						"description": "Invalid ID supplied"
-					},
-					"404": {
-						"description": "Pet not found"
-					}
-				},
-				"security": [
-					{
-						"api_key": []
-					}
-				]
-			},
-			"post": {
-				"tags": [
-					"pet"
-				],
-				"summary": "Updates a pet in the store with form data",
-				"description": "",
-				"operationId": "updatePetWithForm",
-				"consumes": [
-					"application/x-www-form-urlencoded"
-				],
-				"produces": [
-					"application/xml",
-					"application/json"
-				],
-				"parameters": [
-					{
-						"name": "petId",
-						"in": "path",
-						"description": "ID of pet that needs to be updated",
-						"required": true,
-						"type": "integer",
-						"format": "int64"
-					},
-					{
-						"name": "name",
-						"in": "formData",
-						"description": "Updated name of the pet",
-						"required": false,
-						"type": "string"
-					},
-					{
-						"name": "status",
-						"in": "formData",
-						"description": "Updated status of the pet",
-						"required": false,
-						"type": "string"
-					}
-				],
-				"responses": {
-					"405": {
-						"description": "Invalid input"
-					}
-				},
-				"security": [
-					{
-						"petstore_auth": [
-							"write:pets",
-							"read:pets"
-						]
-					}
-				]
-			},
-			"delete": {
-				"tags": [
-					"pet"
-				],
-				"summary": "Deletes a pet",
-				"description": "",
-				"operationId": "deletePet",
-				"produces": [
-					"application/xml",
-					"application/json"
-				],
-				"parameters": [
-					{
-						"name": "api_key",
-						"in": "header",
-						"required": false,
-						"type": "string",
-						"x-example": "Bearer <TOKEN>"
-					},
-					{
-						"name": "petId",
-						"in": "path",
-						"description": "Pet id to delete",
-						"required": true,
-						"type": "integer",
-						"format": "int64"
-					}
-				],
-				"responses": {
-					"400": {
-						"description": "Invalid pet value"
-					}
-				},
-				"security": [
-					{
-						"petstore_auth": [
-							"write:pets",
-							"read:pets"
-						]
-					}
-				]
-			}
-		},
-		"/pet/{petId}/uploadImage": {
-			"post": {
-				"tags": [
-					"pet"
-				],
-				"summary": "uploads an image",
-				"description": "",
-				"operationId": "uploadFile",
-				"consumes": [
-					"multipart/form-data"
-				],
-				"produces": [
-					"application/json"
-				],
-				"parameters": [
-					{
-						"name": "petId",
-						"in": "path",
-						"description": "ID of pet to update",
-						"required": true,
-						"type": "integer",
-						"format": "int64"
-					},
-					{
-						"name": "additionalMetadata",
-						"in": "formData",
-						"description": "Additional data to pass to server",
-						"required": false,
-						"type": "string"
-					},
-					{
-						"name": "file",
-						"in": "formData",
-						"description": "file to upload",
-						"required": false,
-						"type": "file"
-					}
-				],
-				"responses": {
-					"200": {
-						"description": "successful operation",
-						"schema": {
-							"$ref": "#/definitions/ApiResponse"
-						}
-					}
-				},
-				"security": [
-					{
-						"petstore_auth": [
-							"write:pets",
-							"read:pets"
-						]
-					}
-				]
-			}
-		},
-		"/pet/findByStatus": {
-			"get": {
-				"tags": [
-					"pet"
-				],
-				"summary": "Finds Pets by status",
-				"description": "Multiple status values can be provided with comma separated strings",
-				"operationId": "findPetsByStatus",
-				"produces": [
-					"application/xml",
-					"application/json"
-				],
-				"parameters": [
-					{
-						"name": "status",
-						"in": "query",
-						"description": "Status values that need to be considered for filter",
-						"required": true,
-						"type": "array",
-						"items": {
-							"type": "string",
-							"enum": [
-								"available",
-								"pending",
-								"sold"
-							],
-							"default": "available"
-						},
-						"collectionFormat": "csv"
-					}
-				],
-				"responses": {
-					"200": {
-						"description": "successful operation",
-						"schema": {
-							"type": "array",
-							"items": {
-								"$ref": "#/definitions/Pet"
-							}
-						}
-					},
-					"400": {
-						"description": "Invalid status value"
-					}
-				},
-				"security": [
-					{
-						"petstore_auth": [
-							"write:pets",
-							"read:pets"
-						]
-					}
-				]
-			}
-		},
-		"/pet/findByTags": {
-			"get": {
-				"tags": [
-					"pet"
-				],
-				"summary": "Finds Pets by tags",
-				"description": "Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.",
-				"operationId": "findPetsByTags",
-				"deprecated": true,
-				"produces": [
-					"application/xml",
-					"application/json"
-				],
-				"parameters": [
-					{
-						"name": "tags",
-						"in": "query",
-						"description": "Tags to filter by",
-						"required": true,
-						"type": "array",
-						"items": {
-							"type": "string"
-						},
-						"collectionFormat": "csv"
-					}
-				],
-				"responses": {
-					"200": {
-						"description": "successful operation",
-						"schema": {
-							"type": "array",
-							"items": {
-								"$ref": "#/definitions/Pet"
-							}
-						}
-					},
-					"400": {
-						"description": "Invalid tag value"
-					}
-				},
-				"security": [
-					{
-						"petstore_auth": [
-							"write:pets",
-							"read:pets"
-						]
-					}
-				]
-			}
-		},
-		"/store/inventory": {
-			"get": {
-				"tags": [
-					"store"
-				],
-				"summary": "Returns pet inventories by status",
-				"description": "Returns a map of status codes to quantities",
-				"operationId": "getInventory",
-				"produces": [
-					"application/json"
-				],
-				"parameters": [],
-				"responses": {
-					"200": {
-						"description": "successful operation",
-						"schema": {
-							"type": "object",
-							"additionalProperties": {
-								"type": "integer",
-								"format": "int32"
-							}
-						}
-					}
-				},
-				"security": [
-					{
-						"api_key": []
-					}
-				]
-			}
-		},
-		"/store/order": {
-			"post": {
-				"tags": [
-					"store"
-				],
-				"summary": "Place an order for a pet",
-				"description": "",
-				"operationId": "placeOrder",
-				"produces": [
-					"application/xml",
-					"application/json"
-				],
-				"parameters": [
-					{
-						"in": "body",
-						"name": "body",
-						"description": "order placed for purchasing the pet",
-						"required": true,
-						"schema": {
-							"$ref": "#/definitions/Order"
-						}
-					}
-				],
-				"responses": {
-					"200": {
-						"description": "successful operation",
-						"schema": {
-							"$ref": "#/definitions/Order"
-						}
-					},
-					"400": {
-						"description": "Invalid Order"
-					}
-				}
-			}
-		},
-		"/store/order/{orderId}": {
-			"get": {
-				"tags": [
-					"store"
-				],
-				"summary": "Find purchase order by ID",
-				"description": "For valid response try integer IDs with value <= 5 or > 10. Other values will generated exceptions",
-				"operationId": "getOrderById",
-				"produces": [
-					"application/xml",
-					"application/json"
-				],
-				"parameters": [
-					{
-						"name": "orderId",
-						"in": "path",
-						"description": "ID of pet that needs to be fetched",
-						"required": true,
-						"type": "integer",
-						"maximum": 5,
-						"minimum": 1,
-						"format": "int64"
-					}
-				],
-				"responses": {
-					"200": {
-						"description": "successful operation",
-						"schema": {
-							"$ref": "#/definitions/Order"
-						}
-					},
-					"400": {
-						"description": "Invalid ID supplied"
-					},
-					"404": {
-						"description": "Order not found"
-					}
-				}
-			},
-			"delete": {
-				"tags": [
-					"store"
-				],
-				"summary": "Delete purchase order by ID",
-				"description": "For valid response try integer IDs with value < 1000. Anything above 1000 or nonintegers will generate API errors",
-				"operationId": "deleteOrder",
-				"produces": [
-					"application/xml",
-					"application/json"
-				],
-				"parameters": [
-					{
-						"name": "orderId",
-						"in": "path",
-						"description": "ID of the order that needs to be deleted",
-						"required": true,
-						"type": "string",
-						"minimum": 1
-					}
-				],
-				"responses": {
-					"400": {
-						"description": "Invalid ID supplied"
-					},
-					"404": {
-						"description": "Order not found"
-					}
-				}
-			}
-		},
-		"/user": {
-			"post": {
-				"tags": [
-					"user"
-				],
-				"summary": "Create user",
-				"description": "This can only be done by the logged in user.",
-				"operationId": "createUser",
-				"produces": [
-					"application/xml",
-					"application/json"
-				],
-				"parameters": [
-					{
-						"in": "body",
-						"name": "body",
-						"description": "Created user object",
-						"required": true,
-						"schema": {
-							"$ref": "#/definitions/User"
-						}
-					}
-				],
-				"responses": {
-					"default": {
-						"description": "successful operation"
-					}
-				}
-			}
-		},
-		"/user/{username}": {
-			"get": {
-				"tags": [
-					"user"
-				],
-				"summary": "Get user by user name",
-				"description": "",
-				"operationId": "getUserByName",
-				"produces": [
-					"application/xml",
-					"application/json"
-				],
-				"parameters": [
-					{
-						"name": "username",
-						"in": "path",
-						"description": "The name that needs to be fetched. Use user1 for testing. ",
-						"required": true,
-						"type": "string"
-					}
-				],
-				"responses": {
-					"200": {
-						"description": "successful operation",
-						"schema": {
-							"$ref": "#/definitions/User"
-						}
-					},
-					"400": {
-						"description": "Invalid username supplied"
-					},
-					"404": {
-						"description": "User not found"
-					}
-				}
-			},
-			"put": {
-				"tags": [
-					"user"
-				],
-				"summary": "Updated user",
-				"description": "This can only be done by the logged in user.",
-				"operationId": "updateUser",
-				"produces": [
-					"application/xml",
-					"application/json"
-				],
-				"parameters": [
-					{
-						"name": "username",
-						"in": "path",
-						"description": "name that need to be deleted",
-						"required": true,
-						"type": "string"
-					},
-					{
-						"in": "body",
-						"name": "body",
-						"description": "Updated user object",
-						"required": true,
-						"schema": {
-							"$ref": "#/definitions/User"
-						}
-					}
-				],
-				"responses": {
-					"400": {
-						"description": "Invalid user supplied"
-					},
-					"404": {
-						"description": "User not found"
-					}
-				}
-			},
-			"delete": {
-				"tags": [
-					"user"
-				],
-				"summary": "Delete user",
-				"description": "This can only be done by the logged in user.",
-				"operationId": "deleteUser",
-				"produces": [
-					"application/xml",
-					"application/json"
-				],
-				"parameters": [
-					{
-						"name": "username",
-						"in": "path",
-						"description": "The name that needs to be deleted",
-						"required": true,
-						"type": "string"
-					}
-				],
-				"responses": {
-					"400": {
-						"description": "Invalid username supplied"
-					},
-					"404": {
-						"description": "User not found"
-					}
-				}
-			}
-		},
-		"/user/createWithArray": {
-			"post": {
-				"tags": [
-					"user"
-				],
-				"summary": "Creates list of users with given input array",
-				"description": "",
-				"operationId": "createUsersWithArrayInput",
-				"produces": [
-					"application/xml",
-					"application/json"
-				],
-				"parameters": [
-					{
-						"in": "body",
-						"name": "body",
-						"description": "List of user object",
-						"required": true,
-						"schema": {
-							"type": "array",
-							"items": {
-								"$ref": "#/definitions/User"
-							}
-						}
-					}
-				],
-				"responses": {
-					"default": {
-						"description": "successful operation"
-					}
-				}
-			}
-		},
-		"/user/createWithList": {
-			"post": {
-				"tags": [
-					"user"
-				],
-				"summary": "Creates list of users with given input array",
-				"description": "",
-				"operationId": "createUsersWithListInput",
-				"produces": [
-					"application/xml",
-					"application/json"
-				],
-				"parameters": [
-					{
-						"in": "body",
-						"name": "body",
-						"description": "List of user object",
-						"required": true,
-						"schema": {
-							"type": "array",
-							"items": {
-								"$ref": "#/definitions/User"
-							}
-						}
-					}
-				],
-				"responses": {
-					"default": {
-						"description": "successful operation"
-					}
-				}
-			}
-		},
-		"/user/login": {
-			"get": {
-				"tags": [
-					"user"
-				],
-				"summary": "Logs user into the system",
-				"description": "",
-				"operationId": "loginUser",
-				"produces": [
-					"application/xml",
-					"application/json"
-				],
-				"parameters": [
-					{
-						"name": "username",
-						"in": "query",
-						"description": "The user name for login",
-						"required": true,
-						"type": "string"
-					},
-					{
-						"name": "password",
-						"in": "query",
-						"description": "The password for login in clear text",
-						"required": true,
-						"type": "string"
-					}
-				],
-				"responses": {
-					"200": {
-						"description": "successful operation",
-						"schema": {
-							"type": "string"
-						},
-						"examples": {
-							"application/json": "OK",
-							"application/xml": "<message> OK </message>",
-							"text/plain": "OK"
-						},
-						"headers": {
-							"X-Rate-Limit": {
-								"type": "integer",
-								"format": "int32",
-								"description": "calls per hour allowed by the user"
-							},
-							"X-Expires-After": {
-								"type": "string",
-								"format": "date-time",
-								"description": "date in UTC when toekn expires"
-							}
-						}
-					},
-					"400": {
-						"description": "Invalid username/password supplied"
-					}
-				}
-			}
-		},
-		"/user/logout": {
-			"get": {
-				"tags": [
-					"user"
-				],
-				"summary": "Logs out current logged in user session",
-				"description": "",
-				"operationId": "logoutUser",
-				"produces": [
-					"application/xml",
-					"application/json"
-				],
-				"parameters": [],
-				"responses": {
-					"default": {
-						"description": "successful operation"
-					}
-				}
-			}
-		}
-	},
-	"definitions": {
-		"ApiResponse": {
-			"type": "object",
-			"properties": {
-				"code": {
-					"type": "integer",
-					"format": "int32"
-				},
-				"type": {
-					"type": "string"
-				},
-				"message": {
-					"type": "string"
-				}
-			}
-		},
-		"Cat": {
-			"description": "A representation of a cat",
-			"allOf": [
-				{
-					"$ref": "#/definitions/Pet"
-				},
-				{
-					"type": "object",
-					"properties": {
-						"huntingSkill": {
-							"type": "string",
-							"description": "The measured skill for hunting",
-							"default": "lazy",
-							"enum": [
-								"clueless",
-								"lazy",
-								"adventurous",
-								"aggressive"
-							]
-						}
-					},
-					"required": [
-						"huntingSkill"
-					]
-				}
-			]
-		},
-		"Category": {
-			"type": "object",
-			"properties": {
-				"id": {
-					"description": "Category ID",
-					"allOf": [
-						{
-							"$ref": "#/definitions/Id"
-						}
-					]
-				},
-				"name": {
-					"description": "Category name",
-					"type": "string",
-					"minLength": 1
-				},
-				"sub": {
-					"description": "Test Sub Category",
-					"type": "object",
-					"properties": {
-						"prop1": {
-							"type": "string",
-							"description": "Dumb Property"
-						}
-					}
-				}
-			},
-			"xml": {
-				"name": "Category"
-			}
-		},
-		"Dog": {
-			"description": "A representation of a dog",
-			"allOf": [
-				{
-					"$ref": "#/definitions/Pet"
-				},
-				{
-					"type": "object",
-					"properties": {
-						"packSize": {
-							"type": "integer",
-							"format": "int32",
-							"description": "The size of the pack the dog is from",
-							"default": 1,
-							"minimum": 1
-						}
-					},
-					"required": [
-						"packSize"
-					]
-				}
-			]
-		},
-		"HoneyBee": {
-			"description": "A representation of a honey bee",
-			"allOf": [
-				{
-					"$ref": "#/definitions/Pet"
-				},
-				{
-					"type": "object",
-					"properties": {
-						"honeyPerDay": {
-							"type": "number",
-							"description": "Average amount of honey produced per day in ounces",
-							"example": 3.14
-						}
-					},
-					"required": [
-						"honeyPerDay"
-					]
-				}
-			]
-		},
-		"Id": {
-			"type": "integer",
-			"format": "int64"
-		},
-		"Order": {
-			"type": "object",
-			"properties": {
-				"id": {
-					"description": "Order ID",
-					"allOf": [
-						{
-							"$ref": "#/definitions/Id"
-						}
-					]
-				},
-				"petId": {
-					"description": "Pet ID",
-					"allOf": [
-						{
-							"$ref": "#/definitions/Id"
-						}
-					]
-				},
-				"quantity": {
-					"type": "integer",
-					"format": "int32",
-					"minimum": 1,
-					"default": 1
-				},
-				"shipDate": {
-					"description": "Estimated ship date",
-					"type": "string",
-					"format": "date-time"
-				},
-				"status": {
-					"type": "string",
-					"description": "Order Status",
-					"enum": [
-						"placed",
-						"approved",
-						"delivered"
-					]
-				},
-				"complete": {
-					"description": "Indicates whenever order was completed or not",
-					"type": "boolean",
-					"default": false
-				}
-			},
-			"xml": {
-				"name": "Order"
-			}
-		},
-		"Pet": {
-			"type": "object",
-			"required": [
-				"name",
-				"photoUrls"
-			],
-			"discriminator": "petType",
-			"properties": {
-				"id": {
-					"description": "Pet ID",
-					"allOf": [
-						{
-							"$ref": "#/definitions/Id"
-						}
-					]
-				},
-				"category": {
-					"description": "Categories this pet belongs to",
-					"allOf": [
-						{
-							"$ref": "#/definitions/Category"
-						}
-					]
-				},
-				"name": {
-					"description": "The name given to a pet",
-					"type": "string",
-					"example": "Guru"
-				},
-				"photoUrls": {
-					"description": "The list of URL to a cute photos featuring pet",
-					"type": "array",
-					"xml": {
-						"name": "photoUrl",
-						"wrapped": true
-					},
-					"items": {
-						"type": "string",
-						"format": "url"
-					}
-				},
-				"tags": {
-					"description": "Tags attached to the pet",
-					"type": "array",
-					"xml": {
-						"name": "tag",
-						"wrapped": true
-					},
-					"items": {
-						"$ref": "#/definitions/Tag"
-					}
-				},
-				"status": {
-					"type": "string",
-					"description": "Pet status in the store",
-					"enum": [
-						"available",
-						"pending",
-						"sold"
-					]
-				},
-				"petType": {
-					"description": "Type of a pet",
-					"type": "string"
-				}
-			},
-			"xml": {
-				"name": "Pet"
-			}
-		},
-		"Tag": {
-			"type": "object",
-			"properties": {
-				"id": {
-					"description": "Tag ID",
-					"allOf": [
-						{
-							"$ref": "#/definitions/Id"
-						}
-					]
-				},
-				"name": {
-					"description": "Tag name",
-					"type": "string",
-					"minLength": 1
-				}
-			},
-			"xml": {
-				"name": "Tag"
-			}
-		},
-		"User": {
-			"type": "object",
-			"properties": {
-				"id": {
-					"description": "User ID",
-					"$ref": "#/definitions/Id"
-				},
-				"username": {
-					"description": "User supplied username",
-					"type": "string",
-					"minLength": 4,
-					"example": "John78"
-				},
-				"firstName": {
-					"description": "User first name",
-					"type": "string",
-					"minLength": 1,
-					"example": "John"
-				},
-				"lastName": {
-					"description": "User last name",
-					"type": "string",
-					"minLength": 1,
-					"example": "Smith"
-				},
-				"email": {
-					"description": "User email address",
-					"type": "string",
-					"format": "email",
-					"example": "john.smith@example.com"
-				},
-				"password": {
-					"type": "string",
-					"description": "User password, MUST contain a mix of upper and lower case letters, as well as digits",
-					"format": "password",
-					"minLength": 8,
-					"pattern": "(?=.*[a-z])(?=.*[A-Z])(?=.*[0-9])",
-					"example": "drowssaP123"
-				},
-				"phone": {
-					"description": "User phone number in international format",
-					"type": "string",
-					"pattern": "^\\+(?:[0-9]-?){6,14}[0-9]$",
-					"example": "+1-202-555-0192",
-					"x-nullable": true
-				},
-				"userStatus": {
-					"description": "User status",
-					"type": "integer",
-					"format": "int32"
-				}
-			},
-			"xml": {
-				"name": "User"
-			}
-		}
-	}
+  "swagger": "2.0",
+  "schemes": ["http", "https"],
+  "host": "petstore.swagger.io",
+  "basePath": "/v2",
+  "info": {
+    "description": "This is a sample server Petstore server.\nYou can find out more about Swagger at\n[http://swagger.io](http://swagger.io) or on [irc.freenode.net, #swagger](http://swagger.io/irc/).\nFor this sample, you can use the api key `special-key` to test the authorization filters.\n# Introduction\nThis API is documented in **OpenAPI format** and is based on\n[Petstore sample](http://petstore.swagger.io/) provided by [swagger.io](http://swagger.io) team.\nIt was **extended** to illustrate features of [generator-openapi-repo](https://github.com/Rebilly/generator-openapi-repo)\ntool and [ReDoc](https://github.com/Rebilly/ReDoc) documentation. In addition to standard\nOpenAPI syntax we use a few [vendor extensions](https://github.com/Rebilly/ReDoc/blob/master/docs/redoc-vendor-extensions.md).\n# OpenAPI Specification\nThis API is documented in **OpenAPI format** and is based on\n[Petstore sample](http://petstore.swagger.io/) provided by [swagger.io](http://swagger.io) team.\nIt was **extended** to illustrate features of [generator-openapi-repo](https://github.com/Rebilly/generator-openapi-repo)\ntool and [ReDoc](https://github.com/Rebilly/ReDoc) documentation. In addition to standard\nOpenAPI syntax we use a few [vendor extensions](https://github.com/Rebilly/ReDoc/blob/master/docs/redoc-vendor-extensions.md).\n# Cross-Origin Resource Sharing\nThis API features Cross-Origin Resource Sharing (CORS) implemented in compliance with  [W3C spec](https://www.w3.org/TR/cors/).\nAnd that allows cross-domain communication from the browser.\nAll responses have a wildcard same-origin which makes them completely public and accessible to everyone, including any code on any site.\n# Authentication\nPetstore offers two forms of authentication:\n  - API Key\n  - OAuth2\n\nOAuth2 - an open protocol to allow secure authorization in a simple\nand standard method from web, mobile and desktop applications.\n<!-- ReDoc-Inject: <security-definitions> -->\n",
+    "version": "1.0.0",
+    "title": "Swagger Petstore",
+    "termsOfService": "http://swagger.io/terms/",
+    "contact": {
+      "email": "apiteam@swagger.io",
+      "url": "https://github.com/Rebilly/ReDoc"
+    },
+    "x-logo": {
+      "url": "https://rebilly.github.io/ReDoc/petstore-logo.png"
+    },
+    "license": {
+      "name": "Apache 2.0",
+      "url": "http://www.apache.org/licenses/LICENSE-2.0.html"
+    }
+  },
+  "externalDocs": {
+    "description": "Find out how to create Github repo for your OpenAPI spec.",
+    "url": "https://github.com/Rebilly/generator-openapi-repo"
+  },
+  "tags": [
+    {
+      "name": "pet",
+      "description": "Everything about your Pets"
+    },
+    {
+      "name": "store",
+      "description": "Access to Petstore orders"
+    },
+    {
+      "name": "user",
+      "description": "Operations about user"
+    }
+  ],
+  "x-tagGroups": [
+    {
+      "name": "General",
+      "tags": ["pet", "store"]
+    },
+    {
+      "name": "User Management",
+      "tags": ["user"]
+    }
+  ],
+  "securityDefinitions": {
+    "petstore_auth": {
+      "description": "Get access to data while protecting your account credentials.\nOAuth2 is also a safer and more secure way to give you access.\n",
+      "type": "oauth2",
+      "authorizationUrl": "http://petstore.swagger.io/api/oauth/dialog",
+      "flow": "implicit",
+      "scopes": {
+        "write:pets": "modify pets in your account",
+        "read:pets": "read your pets"
+      }
+    },
+    "api_key": {
+      "description": "For this sample, you can use the api key `special-key` to test the authorization filters.\n",
+      "type": "apiKey",
+      "name": "api_key",
+      "in": "header"
+    }
+  },
+  "x-servers": [
+    {
+      "url": "//petstore.swagger.io/v2",
+      "description": "Default server"
+    },
+    {
+      "url": "//petstore.swagger.io/sandbox",
+      "description": "Sandbox server"
+    }
+  ],
+  "paths": {
+    "/pet": {
+      "post": {
+        "tags": ["pet"],
+        "summary": "Add a new pet to the store",
+        "description": "Add new pet to the store inventory.",
+        "operationId": "addPet",
+        "consumes": ["application/json", "application/xml"],
+        "produces": ["application/xml", "application/json"],
+        "parameters": [
+          {
+            "in": "body",
+            "name": "body",
+            "description": "Pet object that needs to be added to the store",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/Pet"
+            }
+          }
+        ],
+        "responses": {
+          "405": {
+            "description": "Invalid input"
+          }
+        },
+        "security": [
+          {
+            "petstore_auth": ["write:pets", "read:pets"]
+          }
+        ],
+        "x-code-samples": [
+          {
+            "lang": "C#",
+            "source": "PetStore.v1.Pet pet = new PetStore.v1.Pet();\npet.setApiKey(\"your api key\");\npet.petType = PetStore.v1.Pet.TYPE_DOG;\npet.name = \"Rex\";\n// set other fields\nPetStoreResponse response = pet.create();\nif (response.statusCode == HttpStatusCode.Created)\n{\n  // Successfully created\n}\nelse\n{\n  // Something wrong -- check response for errors\n  Console.WriteLine(response.getRawResponse());\n}\n"
+          },
+          {
+            "lang": "PHP",
+            "source": "$form = new \\PetStore\\Entities\\Pet();\n$form->setPetType(\"Dog\");\n$form->setName(\"Rex\");\n// set other fields\ntry {\n    $pet = $client->pets()->create($form);\n} catch (UnprocessableEntityException $e) {\n    var_dump($e->getErrors());\n}\n"
+          }
+        ]
+      },
+      "put": {
+        "tags": ["pet"],
+        "summary": "Update an existing pet",
+        "description": "",
+        "operationId": "updatePet",
+        "consumes": ["application/json", "application/xml"],
+        "produces": ["application/xml", "application/json"],
+        "parameters": [
+          {
+            "in": "body",
+            "name": "body",
+            "description": "Pet object that needs to be added to the store",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/Pet"
+            }
+          }
+        ],
+        "responses": {
+          "400": {
+            "description": "Invalid ID supplied"
+          },
+          "404": {
+            "description": "Pet not found"
+          },
+          "405": {
+            "description": "Validation exception"
+          }
+        },
+        "security": [
+          {
+            "petstore_auth": ["write:pets", "read:pets"]
+          }
+        ],
+        "x-code-samples": [
+          {
+            "lang": "PHP",
+            "source": "$form = new \\PetStore\\Entities\\Pet();\n$form->setPetId(1);\n$form->setPetType(\"Dog\");\n$form->setName(\"Rex\");\n// set other fields\ntry {\n    $pet = $client->pets()->update($form);\n} catch (UnprocessableEntityException $e) {\n    var_dump($e->getErrors());\n}\n"
+          }
+        ]
+      }
+    },
+    "/pet/{petId}": {
+      "get": {
+        "tags": ["pet"],
+        "summary": "Find pet by ID",
+        "description": "Returns a single pet",
+        "operationId": "getPetById",
+        "produces": ["application/xml", "application/json"],
+        "parameters": [
+          {
+            "name": "petId",
+            "in": "path",
+            "description": "ID of pet to return",
+            "required": true,
+            "type": "integer",
+            "format": "int64"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "schema": {
+              "$ref": "#/definitions/Pet"
+            }
+          },
+          "400": {
+            "description": "Invalid ID supplied"
+          },
+          "404": {
+            "description": "Pet not found"
+          }
+        },
+        "security": [
+          {
+            "api_key": []
+          }
+        ]
+      },
+      "post": {
+        "tags": ["pet"],
+        "summary": "Updates a pet in the store with form data",
+        "description": "",
+        "operationId": "updatePetWithForm",
+        "consumes": ["application/x-www-form-urlencoded"],
+        "produces": ["application/xml", "application/json"],
+        "parameters": [
+          {
+            "name": "petId",
+            "in": "path",
+            "description": "ID of pet that needs to be updated",
+            "required": true,
+            "type": "integer",
+            "format": "int64"
+          },
+          {
+            "name": "name",
+            "in": "formData",
+            "description": "Updated name of the pet",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "status",
+            "in": "formData",
+            "description": "Updated status of the pet",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "405": {
+            "description": "Invalid input"
+          }
+        },
+        "security": [
+          {
+            "petstore_auth": ["write:pets", "read:pets"]
+          }
+        ]
+      },
+      "delete": {
+        "tags": ["pet"],
+        "summary": "Deletes a pet",
+        "description": "",
+        "operationId": "deletePet",
+        "produces": ["application/xml", "application/json"],
+        "parameters": [
+          {
+            "name": "api_key",
+            "in": "header",
+            "required": false,
+            "type": "string",
+            "x-example": "Bearer <TOKEN>"
+          },
+          {
+            "name": "petId",
+            "in": "path",
+            "description": "Pet id to delete",
+            "required": true,
+            "type": "integer",
+            "format": "int64"
+          }
+        ],
+        "responses": {
+          "400": {
+            "description": "Invalid pet value"
+          }
+        },
+        "security": [
+          {
+            "petstore_auth": ["write:pets", "read:pets"]
+          }
+        ]
+      }
+    },
+    "/pet/{petId}/uploadImage": {
+      "post": {
+        "tags": ["pet"],
+        "summary": "uploads an image",
+        "description": "",
+        "operationId": "uploadFile",
+        "consumes": ["multipart/form-data"],
+        "produces": ["application/json"],
+        "parameters": [
+          {
+            "name": "petId",
+            "in": "path",
+            "description": "ID of pet to update",
+            "required": true,
+            "type": "integer",
+            "format": "int64"
+          },
+          {
+            "name": "additionalMetadata",
+            "in": "formData",
+            "description": "Additional data to pass to server",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "file",
+            "in": "formData",
+            "description": "file to upload",
+            "required": false,
+            "type": "file"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "schema": {
+              "$ref": "#/definitions/ApiResponse"
+            }
+          }
+        },
+        "security": [
+          {
+            "petstore_auth": ["write:pets", "read:pets"]
+          }
+        ]
+      }
+    },
+    "/pet/findByStatus": {
+      "get": {
+        "tags": ["pet"],
+        "summary": "Finds Pets by status",
+        "description": "Multiple status values can be provided with comma separated strings",
+        "operationId": "findPetsByStatus",
+        "produces": ["application/xml", "application/json"],
+        "parameters": [
+          {
+            "name": "status",
+            "in": "query",
+            "description": "Status values that need to be considered for filter",
+            "required": true,
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": ["available", "pending", "sold"],
+              "default": "available"
+            },
+            "collectionFormat": "csv"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Pet"
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid status value"
+          }
+        },
+        "security": [
+          {
+            "petstore_auth": ["write:pets", "read:pets"]
+          }
+        ]
+      }
+    },
+    "/pet/findByTags": {
+      "get": {
+        "tags": ["pet"],
+        "summary": "Finds Pets by tags",
+        "description": "Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.",
+        "operationId": "findPetsByTags",
+        "deprecated": true,
+        "produces": ["application/xml", "application/json"],
+        "parameters": [
+          {
+            "name": "tags",
+            "in": "query",
+            "description": "Tags to filter by",
+            "required": true,
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "collectionFormat": "csv"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Pet"
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid tag value"
+          }
+        },
+        "security": [
+          {
+            "petstore_auth": ["write:pets", "read:pets"]
+          }
+        ]
+      }
+    },
+    "/store/inventory": {
+      "get": {
+        "tags": ["store"],
+        "summary": "Returns pet inventories by status",
+        "description": "Returns a map of status codes to quantities",
+        "operationId": "getInventory",
+        "produces": ["application/json"],
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "schema": {
+              "type": "object",
+              "additionalProperties": {
+                "type": "integer",
+                "format": "int32"
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "api_key": []
+          }
+        ]
+      }
+    },
+    "/store/order": {
+      "post": {
+        "tags": ["store"],
+        "summary": "Place an order for a pet",
+        "description": "",
+        "operationId": "placeOrder",
+        "produces": ["application/xml", "application/json"],
+        "parameters": [
+          {
+            "in": "body",
+            "name": "body",
+            "description": "order placed for purchasing the pet",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/Order"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "schema": {
+              "$ref": "#/definitions/Order"
+            }
+          },
+          "400": {
+            "description": "Invalid Order"
+          }
+        }
+      }
+    },
+    "/store/order/{orderId}": {
+      "get": {
+        "tags": ["store"],
+        "summary": "Find purchase order by ID",
+        "description": "For valid response try integer IDs with value <= 5 or > 10. Other values will generated exceptions",
+        "operationId": "getOrderById",
+        "produces": ["application/xml", "application/json"],
+        "parameters": [
+          {
+            "name": "orderId",
+            "in": "path",
+            "description": "ID of pet that needs to be fetched",
+            "required": true,
+            "type": "integer",
+            "maximum": 5,
+            "minimum": 1,
+            "format": "int64"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "schema": {
+              "$ref": "#/definitions/Order"
+            }
+          },
+          "400": {
+            "description": "Invalid ID supplied"
+          },
+          "404": {
+            "description": "Order not found"
+          }
+        }
+      },
+      "delete": {
+        "tags": ["store"],
+        "summary": "Delete purchase order by ID",
+        "description": "For valid response try integer IDs with value < 1000. Anything above 1000 or nonintegers will generate API errors",
+        "operationId": "deleteOrder",
+        "produces": ["application/xml", "application/json"],
+        "parameters": [
+          {
+            "name": "orderId",
+            "in": "path",
+            "description": "ID of the order that needs to be deleted",
+            "required": true,
+            "type": "string",
+            "minimum": 1
+          }
+        ],
+        "responses": {
+          "400": {
+            "description": "Invalid ID supplied"
+          },
+          "404": {
+            "description": "Order not found"
+          }
+        }
+      }
+    },
+    "/user": {
+      "post": {
+        "tags": ["user"],
+        "summary": "Create user",
+        "description": "This can only be done by the logged in user.",
+        "operationId": "createUser",
+        "produces": ["application/xml", "application/json"],
+        "parameters": [
+          {
+            "in": "body",
+            "name": "body",
+            "description": "Created user object",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/User"
+            }
+          }
+        ],
+        "responses": {
+          "default": {
+            "description": "successful operation"
+          }
+        }
+      }
+    },
+    "/user/{username}": {
+      "get": {
+        "tags": ["user"],
+        "summary": "Get user by user name",
+        "description": "",
+        "operationId": "getUserByName",
+        "produces": ["application/xml", "application/json"],
+        "parameters": [
+          {
+            "name": "username",
+            "in": "path",
+            "description": "The name that needs to be fetched. Use user1 for testing. ",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "schema": {
+              "$ref": "#/definitions/User"
+            }
+          },
+          "400": {
+            "description": "Invalid username supplied"
+          },
+          "404": {
+            "description": "User not found"
+          }
+        }
+      },
+      "put": {
+        "tags": ["user"],
+        "summary": "Updated user",
+        "description": "This can only be done by the logged in user.",
+        "operationId": "updateUser",
+        "produces": ["application/xml", "application/json"],
+        "parameters": [
+          {
+            "name": "username",
+            "in": "path",
+            "description": "name that need to be deleted",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "description": "Updated user object",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/User"
+            }
+          }
+        ],
+        "responses": {
+          "400": {
+            "description": "Invalid user supplied"
+          },
+          "404": {
+            "description": "User not found"
+          }
+        }
+      },
+      "delete": {
+        "tags": ["user"],
+        "summary": "Delete user",
+        "description": "This can only be done by the logged in user.",
+        "operationId": "deleteUser",
+        "produces": ["application/xml", "application/json"],
+        "parameters": [
+          {
+            "name": "username",
+            "in": "path",
+            "description": "The name that needs to be deleted",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "400": {
+            "description": "Invalid username supplied"
+          },
+          "404": {
+            "description": "User not found"
+          }
+        }
+      }
+    },
+    "/user/createWithArray": {
+      "post": {
+        "tags": ["user"],
+        "summary": "Creates list of users with given input array",
+        "description": "",
+        "operationId": "createUsersWithArrayInput",
+        "produces": ["application/xml", "application/json"],
+        "parameters": [
+          {
+            "in": "body",
+            "name": "body",
+            "description": "List of user object",
+            "required": true,
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/User"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "default": {
+            "description": "successful operation"
+          }
+        }
+      }
+    },
+    "/user/createWithList": {
+      "post": {
+        "tags": ["user"],
+        "summary": "Creates list of users with given input array",
+        "description": "",
+        "operationId": "createUsersWithListInput",
+        "produces": ["application/xml", "application/json"],
+        "parameters": [
+          {
+            "in": "body",
+            "name": "body",
+            "description": "List of user object",
+            "required": true,
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/User"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "default": {
+            "description": "successful operation"
+          }
+        }
+      }
+    },
+    "/user/login": {
+      "get": {
+        "tags": ["user"],
+        "summary": "Logs user into the system",
+        "description": "",
+        "operationId": "loginUser",
+        "produces": ["application/xml", "application/json"],
+        "parameters": [
+          {
+            "name": "username",
+            "in": "query",
+            "description": "The user name for login",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "password",
+            "in": "query",
+            "description": "The password for login in clear text",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "schema": {
+              "type": "string"
+            },
+            "examples": {
+              "application/json": "OK",
+              "application/xml": "<message> OK </message>",
+              "text/plain": "OK"
+            },
+            "headers": {
+              "X-Rate-Limit": {
+                "type": "integer",
+                "format": "int32",
+                "description": "calls per hour allowed by the user"
+              },
+              "X-Expires-After": {
+                "type": "string",
+                "format": "date-time",
+                "description": "date in UTC when toekn expires"
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid username/password supplied"
+          }
+        }
+      }
+    },
+    "/user/logout": {
+      "get": {
+        "tags": ["user"],
+        "summary": "Logs out current logged in user session",
+        "description": "",
+        "operationId": "logoutUser",
+        "produces": ["application/xml", "application/json"],
+        "parameters": [],
+        "responses": {
+          "default": {
+            "description": "successful operation"
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "ApiResponse": {
+      "type": "object",
+      "properties": {
+        "code": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "type": {
+          "type": "string"
+        },
+        "message": {
+          "type": "string"
+        }
+      }
+    },
+    "Cat": {
+      "description": "A representation of a cat",
+      "allOf": [
+        {
+          "$ref": "#/definitions/Pet"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "huntingSkill": {
+              "type": "string",
+              "description": "The measured skill for hunting",
+              "default": "lazy",
+              "enum": ["clueless", "lazy", "adventurous", "aggressive"]
+            }
+          },
+          "required": ["huntingSkill"]
+        }
+      ]
+    },
+    "Category": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "description": "Category ID",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Id"
+            }
+          ]
+        },
+        "name": {
+          "description": "Category name",
+          "type": "string",
+          "minLength": 1
+        },
+        "sub": {
+          "description": "Test Sub Category",
+          "type": "object",
+          "properties": {
+            "prop1": {
+              "type": "string",
+              "description": "Dumb Property"
+            }
+          }
+        }
+      },
+      "xml": {
+        "name": "Category"
+      }
+    },
+    "Dog": {
+      "description": "A representation of a dog",
+      "allOf": [
+        {
+          "$ref": "#/definitions/Pet"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "packSize": {
+              "type": "integer",
+              "format": "int32",
+              "description": "The size of the pack the dog is from",
+              "default": 1,
+              "minimum": 1
+            }
+          },
+          "required": ["packSize"]
+        }
+      ]
+    },
+    "HoneyBee": {
+      "description": "A representation of a honey bee",
+      "allOf": [
+        {
+          "$ref": "#/definitions/Pet"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "honeyPerDay": {
+              "type": "number",
+              "description": "Average amount of honey produced per day in ounces",
+              "example": 3.14
+            }
+          },
+          "required": ["honeyPerDay"]
+        }
+      ]
+    },
+    "Id": {
+      "type": "integer",
+      "format": "int64"
+    },
+    "Order": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "description": "Order ID",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Id"
+            }
+          ]
+        },
+        "petId": {
+          "description": "Pet ID",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Id"
+            }
+          ]
+        },
+        "quantity": {
+          "type": "integer",
+          "format": "int32",
+          "minimum": 1,
+          "default": 1
+        },
+        "shipDate": {
+          "description": "Estimated ship date",
+          "type": "string",
+          "format": "date-time"
+        },
+        "status": {
+          "type": "string",
+          "description": "Order Status",
+          "enum": ["placed", "approved", "delivered"]
+        },
+        "complete": {
+          "description": "Indicates whenever order was completed or not",
+          "type": "boolean",
+          "default": false
+        }
+      },
+      "xml": {
+        "name": "Order"
+      }
+    },
+    "Pet": {
+      "type": "object",
+      "required": ["name", "photoUrls"],
+      "discriminator": "petType",
+      "properties": {
+        "id": {
+          "description": "Pet ID",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Id"
+            }
+          ]
+        },
+        "category": {
+          "description": "Categories this pet belongs to",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Category"
+            }
+          ]
+        },
+        "name": {
+          "description": "The name given to a pet",
+          "type": "string",
+          "example": "Guru"
+        },
+        "photoUrls": {
+          "description": "The list of URL to a cute photos featuring pet",
+          "type": "array",
+          "xml": {
+            "name": "photoUrl",
+            "wrapped": true
+          },
+          "items": {
+            "type": "string",
+            "format": "url"
+          }
+        },
+        "tags": {
+          "description": "Tags attached to the pet",
+          "type": "array",
+          "xml": {
+            "name": "tag",
+            "wrapped": true
+          },
+          "items": {
+            "$ref": "#/definitions/Tag"
+          }
+        },
+        "status": {
+          "type": "string",
+          "description": "Pet status in the store",
+          "enum": ["available", "pending", "sold"]
+        },
+        "petType": {
+          "description": "Type of a pet",
+          "type": "string"
+        }
+      },
+      "xml": {
+        "name": "Pet"
+      }
+    },
+    "Tag": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "description": "Tag ID",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Id"
+            }
+          ]
+        },
+        "name": {
+          "description": "Tag name",
+          "type": "string",
+          "minLength": 1
+        }
+      },
+      "xml": {
+        "name": "Tag"
+      }
+    },
+    "User": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "description": "User ID",
+          "$ref": "#/definitions/Id"
+        },
+        "username": {
+          "description": "User supplied username",
+          "type": "string",
+          "minLength": 4,
+          "example": "John78"
+        },
+        "firstName": {
+          "description": "User first name",
+          "type": "string",
+          "minLength": 1,
+          "example": "John"
+        },
+        "lastName": {
+          "description": "User last name",
+          "type": "string",
+          "minLength": 1,
+          "example": "Smith"
+        },
+        "email": {
+          "description": "User email address",
+          "type": "string",
+          "format": "email",
+          "example": "john.smith@example.com"
+        },
+        "password": {
+          "type": "string",
+          "description": "User password, MUST contain a mix of upper and lower case letters, as well as digits",
+          "format": "password",
+          "minLength": 8,
+          "pattern": "(?=.*[a-z])(?=.*[A-Z])(?=.*[0-9])",
+          "example": "drowssaP123"
+        },
+        "phone": {
+          "description": "User phone number in international format",
+          "type": "string",
+          "pattern": "^\\+(?:[0-9]-?){6,14}[0-9]$",
+          "example": "+1-202-555-0192",
+          "x-nullable": true
+        },
+        "userStatus": {
+          "description": "User status",
+          "type": "integer",
+          "format": "int32"
+        }
+      },
+      "xml": {
+        "name": "User"
+      }
+    }
+  }
 }

--- a/test/test.js
+++ b/test/test.js
@@ -1,116 +1,198 @@
-'use strict'
+'use strict';
 
-const test = require('tape')
-const OpenAPISnippets = require('../index')
+const test = require('tape');
+const OpenAPISnippets = require('../index');
 
-const InstagramOpenAPI = require('./instagram_swagger.json')
-const BloggerOpenAPI = require('./blogger_swagger.json')
-const GitHubOpenAPI = require('./github_swagger.json')
-const WatsonOpenAPI = require('./watson_alchemy_language_swagger.json')
-const IBMOpenAPI = require('./ibm_watson_alchemy_data_news_api.json')
-const PetStoreOpenAPI = require('./petstore_swagger.json')
-const PetStoreOpenAPI3 = require('./petstore_oas.json')
-const ParameterSchemaReferenceAPI = require('./parameter_schema_reference')
+const InstagramOpenAPI = require('./instagram_swagger.json');
+const BloggerOpenAPI = require('./blogger_swagger.json');
+const GitHubOpenAPI = require('./github_swagger.json');
+const WatsonOpenAPI = require('./watson_alchemy_language_swagger.json');
+const IBMOpenAPI = require('./ibm_watson_alchemy_data_news_api.json');
+const PetStoreOpenAPI = require('./petstore_swagger.json');
+const PetStoreOpenAPI3 = require('./petstore_oas.json');
+const ParameterSchemaReferenceAPI = require('./parameter_schema_reference');
+const ParameterExampleReferenceAPI = require('./parameter_example_swagger.json')
 
 test('Getting snippets should not result in error or undefined', function (t) {
-  t.plan(1)
+  t.plan(1);
 
-  const result = OpenAPISnippets.getSnippets(InstagramOpenAPI, ['c_libcurl'])
-  t.notEqual(result, undefined)
-})
+  const result = OpenAPISnippets.getSnippets(InstagramOpenAPI, ['c_libcurl']);
+  t.notEqual(result, undefined);
+});
 
 test('An invalid target should result in error', function (t) {
-  t.plan(1)
+  t.plan(1);
 
   try {
-    const result = OpenAPISnippets.getSnippets(BloggerOpenAPI, ['node_asfd'])
-    console.log(result)
+    const result = OpenAPISnippets.getSnippets(BloggerOpenAPI, ['node_asfd']);
+    console.log(result);
   } catch (err) {
-    t.equal(err.toString(), 'Error: Invalid target: node_asfd')
+    t.equal(err.toString(), 'Error: Invalid target: node_asfd');
   }
-})
+});
 
 test('Getting snippets for endpoint should not result in error or undefined', function (t) {
-  t.plan(1)
+  t.plan(1);
 
-  const result = OpenAPISnippets.getEndpointSnippets(InstagramOpenAPI, '/geographies/{geo-id}/media/recent', 'get', ['c_libcurl'])
-  t.notEqual(result, undefined)
-})
+  const result = OpenAPISnippets.getEndpointSnippets(
+    InstagramOpenAPI,
+    '/geographies/{geo-id}/media/recent',
+    'get',
+    ['c_libcurl']
+  );
+  t.notEqual(result, undefined);
+});
 
 test('Getting snippets for IBM Watson Alchemy Language should work', function (t) {
-  t.plan(1)
+  t.plan(1);
 
-  const result = OpenAPISnippets.getEndpointSnippets(IBMOpenAPI, '/data/GetNews', 'get', ['node_request'])
-  t.notEqual(result, undefined)
-})
+  const result = OpenAPISnippets.getEndpointSnippets(
+    IBMOpenAPI,
+    '/data/GetNews',
+    'get',
+    ['node_request']
+  );
+  t.notEqual(result, undefined);
+});
 
 test('Getting snippets for endpoint should contain body', function (t) {
-  t.plan(2)
+  t.plan(2);
   // checks the 'Pages' schema...
-  const result = OpenAPISnippets.getEndpointSnippets(BloggerOpenAPI, '/blogs/{blogId}/pages', 'post', ['node_request'])
-  t.true(/body/.test(result.snippets[0].content))
-  t.true(/subPage/.test(result.snippets[0].content))
-})
+  const result = OpenAPISnippets.getEndpointSnippets(
+    BloggerOpenAPI,
+    '/blogs/{blogId}/pages',
+    'post',
+    ['node_request']
+  );
+  t.true(/body/.test(result.snippets[0].content));
+  t.true(/subPage/.test(result.snippets[0].content));
+});
 
 test('Getting snippets from OpenAPI 3.0.x should work', function (t) {
-  t.plan(1)
+  t.plan(1);
   // checks the 'Pages' schema...
-  const result = OpenAPISnippets.getEndpointSnippets(PetStoreOpenAPI3, '/pets/{id}', 'get', ['node_request'])
-  t.notEqual(result, undefined)
-})
+  const result = OpenAPISnippets.getEndpointSnippets(
+    PetStoreOpenAPI3,
+    '/pets/{id}',
+    'get',
+    ['node_request']
+  );
+  t.notEqual(result, undefined);
+});
+
+test('Testing server overrides', function (t) {
+  t.plan(12);
+  const result = OpenAPISnippets.getSnippets(PetStoreOpenAPI3, ['c_libcurl']);
+  t.equal(result[0].url, 'https://method-override.example.com/pets');
+  t.match(result[0].snippets[0].content, /.*method-override.example.com.*/);
+  t.doesNotMatch(result[0].snippets[0].content, /.*petstore.swagger.io.*/);
+  t.equal(result[1].url, 'http://petstore.swagger.io/api/pets/{id}');
+  t.match(result[1].snippets[0].content, /.*petstore.swagger.io.*/);
+  t.doesNotMatch(result[1].snippets[0].content, /.*example.com.*/);
+  t.equal(result[2].url, 'https://path-override.example.com/pets');
+  t.match(result[2].snippets[0].content, /.*path-override.example.com.*/);
+  t.doesNotMatch(result[2].snippets[0].content, /.*petstore.swagger.io.*/);
+  t.equal(result[3].url, 'http://petstore.swagger.io/api/pets/{id}');
+  t.match(result[3].snippets[0].content, /.*petstore.swagger.io.*/);
+  t.doesNotMatch(result[3].snippets[0].content, /.*example.com.*/);
+});
 
 test('Testing optionally provided parameter values', function (t) {
-  t.plan(2)
+  t.plan(2);
   // checks the 'Pages' schema...
-  const result = OpenAPISnippets.getEndpointSnippets(InstagramOpenAPI, '/locations/search', 'get', ['node_request'],
+  const result = OpenAPISnippets.getEndpointSnippets(
+    InstagramOpenAPI,
+    '/locations/search',
+    'get',
+    ['node_request'],
     {
-      'distance': 5000,
-      'not-a-query-param': 'foo'
-    })
-  t.true(/5000/.test(result.snippets[0].content))
-  t.false(/not-a-query-param/.test(result.snippets[0].content))
-})
+      distance: 5000,
+      'not-a-query-param': 'foo',
+    }
+  );
+  t.true(/5000/.test(result.snippets[0].content));
+  t.false(/not-a-query-param/.test(result.snippets[0].content));
+});
 
 test('Testing the case when default is present but a value is provided, use the provided value', function (t) {
-  t.plan(2)
+  t.plan(2);
   // checks the 'Pages' schema...
-  const result = OpenAPISnippets.getEndpointSnippets(GitHubOpenAPI, '/issues', 'get', ['node_request'],
+  const result = OpenAPISnippets.getEndpointSnippets(
+    GitHubOpenAPI,
+    '/issues',
+    'get',
+    ['node_request'],
     {
-      'filter': 'assigned'
-    })
-  t.true(/assigned/.test(result.snippets[0].content))
-  t.false(/all/.test(result.snippets[0].content)) // The default value of `filter` is `all`
-})
+      filter: 'assigned',
+    }
+  );
+  t.true(/assigned/.test(result.snippets[0].content));
+  t.false(/all/.test(result.snippets[0].content)); // The default value of `filter` is `all`
+});
 
 test('Testing the case when default is present but no value is provided, use the default', function (t) {
-  t.plan(2)
+  t.plan(2);
   // checks the 'Pages' schema...
-  const result = OpenAPISnippets.getEndpointSnippets(GitHubOpenAPI, '/issues', 'get', ['node_request'])
-  t.false(/assigned/.test(result.snippets[0].content))
-  t.true(/all/.test(result.snippets[0].content))  // The default value of `filter` is `all`
-})
+  const result = OpenAPISnippets.getEndpointSnippets(
+    GitHubOpenAPI,
+    '/issues',
+    'get',
+    ['node_request']
+  );
+  t.false(/assigned/.test(result.snippets[0].content));
+  t.true(/all/.test(result.snippets[0].content)); // The default value of `filter` is `all`
+});
 
 test('Referenced query parameters should be resolved', function (t) {
-  const result = OpenAPISnippets.getEndpointSnippets(WatsonOpenAPI, '/html/HTMLExtractDates', 'get', ['node_request'])
-  const snippet = result.snippets[0].content
-  t.true(/apikey/.test(snippet))
-  t.true(/showSourceText/.test(snippet))
-  t.end()
-})
+  const result = OpenAPISnippets.getEndpointSnippets(
+    WatsonOpenAPI,
+    '/html/HTMLExtractDates',
+    'get',
+    ['node_request']
+  );
+  const snippet = result.snippets[0].content;
+  t.true(/apikey/.test(snippet));
+  t.true(/showSourceText/.test(snippet));
+  t.end();
+});
 
 test('Resolve samples from nested examples', function (t) {
-  const result = OpenAPISnippets.getEndpointSnippets(PetStoreOpenAPI, '/user', 'post', ['node_request'])
-  const snippet = result.snippets[0].content
-  t.true(/username.*John78\'/.test(snippet))
-  t.true(/email.*john.smith@example.com\'/.test(snippet))
-  t.true(/phone.*\+1\-202\-555\-0192/.test(snippet))
-  t.true(/password.*drowssaP123/.test(snippet))
-  t.end()
-})
+  const result = OpenAPISnippets.getEndpointSnippets(
+    PetStoreOpenAPI,
+    '/user',
+    'post',
+    ['node_request']
+  );
+  const snippet = result.snippets[0].content;
+  t.true(/username.*John78\'/.test(snippet));
+  t.true(/email.*john.smith@example.com\'/.test(snippet));
+  t.true(/phone.*\+1\-202\-555\-0192/.test(snippet));
+  t.true(/password.*drowssaP123/.test(snippet));
+  t.end();
+});
 
 test('Parameters that are Schema References Are Dereferenced', function (t) {
-  const result = OpenAPISnippets.getEndpointSnippets(ParameterSchemaReferenceAPI, '/pets', 'post', ['node_request']);
+  const result = OpenAPISnippets.getEndpointSnippets(
+    ParameterSchemaReferenceAPI,
+    '/pets',
+    'post',
+    ['node_request']
+  );
   const snippet = result.snippets[0].content;
-  t.true(/pet: 'SOME_OBJECT_VALUE'/.test(snippet))
+  t.true(/pet: 'SOME_OBJECT_VALUE'/.test(snippet));
+  t.end();
+});
+
+test('Testing the case when an example is provided, use the provided example value', function (t) {
+  t.plan(2);
+  const result = OpenAPISnippets.getEndpointSnippets(
+    ParameterExampleReferenceAPI,
+    '/pets',
+    'get',
+    ['node_request']
+  );
+  const snippet = result.snippets[0].content;
+  t.true(/ {tags: 'dog,cat', limit: '10'}/.test(snippet));
+  t.false(/SOME_INTEGER_VALUE/.test(snippet));
   t.end();
 });

--- a/test/watson_alchemy_language_swagger.json
+++ b/test/watson_alchemy_language_swagger.json
@@ -1,10 +1,7 @@
 {
   "$loki": 492,
   "basePath": "/calls",
-  "consumes": [
-    "application/x-www-form-urlencoded",
-    "application/json"
-  ],
+  "consumes": ["application/x-www-form-urlencoded", "application/json"],
   "definitions": {
     "Authors Response": {
       "properties": {
@@ -1154,9 +1151,7 @@
     "description": "The AlchemyLanguage API uses natural language processing technology and machine learning algorithms to extract semantic meta-data from content, such as information on people, places, companies, topics, facts, relationships, authors, and languages.",
     "title": "IBM Alchemy Language",
     "version": "1.0.0",
-    "x-tags": [
-      "machine learning"
-    ]
+    "x-tags": ["machine learning"]
   },
   "meta": {
     "created": 1486756139004,
@@ -1230,10 +1225,7 @@
     },
     "disambiguate_formData": {
       "description": "Set this to 0 to hide entity disambiguation information in the response",
-      "enum": [
-        0,
-        1
-      ],
+      "enum": [0, 1],
       "in": "formData",
       "name": "disambiguate",
       "required": false,
@@ -1241,10 +1233,7 @@
     },
     "disambiguate_query": {
       "description": "Set this to 0 to hide entity disambiguation information in the response",
-      "enum": [
-        0,
-        1
-      ],
+      "enum": [0, 1],
       "in": "query",
       "name": "disambiguate",
       "required": false,
@@ -1252,10 +1241,7 @@
     },
     "entities_formData": {
       "description": "Set this to 1 to identify entities in detected relations<br><b>This incurs an additional API transaction</b>",
-      "enum": [
-        0,
-        1
-      ],
+      "enum": [0, 1],
       "in": "formData",
       "name": "entities",
       "required": false,
@@ -1263,10 +1249,7 @@
     },
     "entities_query": {
       "description": "Set this to 1 to identify entities in detected relations<br><b>This incurs an additional API transaction</b>",
-      "enum": [
-        0,
-        1
-      ],
+      "enum": [0, 1],
       "in": "query",
       "name": "entities",
       "required": false,
@@ -1274,10 +1257,7 @@
     },
     "extractLinks_formData": {
       "description": "Set this to 1 to include hyperlinks in the extracted web page text",
-      "enum": [
-        0,
-        1
-      ],
+      "enum": [0, 1],
       "in": "formData",
       "name": "extractLinks",
       "required": false,
@@ -1285,10 +1265,7 @@
     },
     "extractLinks_query": {
       "description": "Set this to 1 to include hyperlinks in the extracted web page text",
-      "enum": [
-        0,
-        1
-      ],
+      "enum": [0, 1],
       "in": "query",
       "name": "extractLinks",
       "required": false,
@@ -1340,10 +1317,7 @@
     },
     "keywordExtractMode_formData": {
       "description": "keyword extraction mode",
-      "enum": [
-        "normal",
-        "strict"
-      ],
+      "enum": ["normal", "strict"],
       "in": "formData",
       "name": "keywordExtractMode",
       "required": false,
@@ -1351,10 +1325,7 @@
     },
     "keywordExtractMode_query": {
       "description": "keyword extraction mode",
-      "enum": [
-        "normal",
-        "strict"
-      ],
+      "enum": ["normal", "strict"],
       "in": "query",
       "name": "keywordExtractMode",
       "required": false,
@@ -1362,10 +1333,7 @@
     },
     "keywords_formData": {
       "description": "Set this to 1 to identify keywords in detected relations<br><b>This incurs an additional API transaction</b>",
-      "enum": [
-        0,
-        1
-      ],
+      "enum": [0, 1],
       "in": "formData",
       "name": "keywords",
       "required": false,
@@ -1373,10 +1341,7 @@
     },
     "keywords_query": {
       "description": "Set this to 1 to identify keywords in detected relations<br><b>This incurs an additional API transaction</b>",
-      "enum": [
-        0,
-        1
-      ],
+      "enum": [0, 1],
       "in": "query",
       "name": "keywords",
       "required": false,
@@ -1384,10 +1349,7 @@
     },
     "knowledgeGraph_formData": {
       "description": "Set to 1 to include knowledge graph information in the results <br><b>Incurs an additional API transaction</b>",
-      "enum": [
-        0,
-        1
-      ],
+      "enum": [0, 1],
       "in": "formData",
       "name": "knowledgeGraph",
       "required": false,
@@ -1395,10 +1357,7 @@
     },
     "knowledgeGraph_formData_combined": {
       "description": "Include knowledge graph information in the results for each applicable function in the combined call. This incurs one additional transaction for each function involved.",
-      "enum": [
-        0,
-        1
-      ],
+      "enum": [0, 1],
       "in": "formData",
       "name": "knowledgeGraph",
       "required": false,
@@ -1406,10 +1365,7 @@
     },
     "knowledgeGraph_query": {
       "description": "Set to 1 to include knowledge graph information in the results <br><b>Incurs an additional API transaction</b>",
-      "enum": [
-        0,
-        1
-      ],
+      "enum": [0, 1],
       "in": "query",
       "name": "knowledgeGraph",
       "required": false,
@@ -1417,10 +1373,7 @@
     },
     "knowledgeGraph_query_combined": {
       "description": "Include knowledge graph information in the results for each applicable function in the combined call. This incurs one additional transaction for each function involved.",
-      "enum": [
-        0,
-        1
-      ],
+      "enum": [0, 1],
       "in": "query",
       "name": "knowledgeGraph",
       "required": false,
@@ -1428,10 +1381,7 @@
     },
     "linkedData_formData": {
       "description": "Set this to 0 to disable linkedData links in the response",
-      "enum": [
-        0,
-        1
-      ],
+      "enum": [0, 1],
       "in": "formData",
       "name": "linkedData",
       "required": false,
@@ -1439,10 +1389,7 @@
     },
     "linkedData_query": {
       "description": "Set this to 0 to disable linkedData links in the response",
-      "enum": [
-        0,
-        1
-      ],
+      "enum": [0, 1],
       "in": "query",
       "name": "linkedData",
       "required": false,
@@ -1548,11 +1495,7 @@
     },
     "outputMode_formData": {
       "description": "Desired response format (default XML)",
-      "enum": [
-        "json",
-        "rdf",
-        "xml"
-      ],
+      "enum": ["json", "rdf", "xml"],
       "in": "formData",
       "name": "outputMode",
       "required": false,
@@ -1560,11 +1503,7 @@
     },
     "outputMode_query": {
       "description": "Desired response format (default XML)",
-      "enum": [
-        "json",
-        "rdf",
-        "xml"
-      ],
+      "enum": ["json", "rdf", "xml"],
       "in": "query",
       "name": "outputMode",
       "required": false,
@@ -1572,10 +1511,7 @@
     },
     "quotations_formData": {
       "description": "Set this to 1 to return quotations associated with detected entities",
-      "enum": [
-        0,
-        1
-      ],
+      "enum": [0, 1],
       "in": "formData",
       "name": "quotations",
       "required": false,
@@ -1583,10 +1519,7 @@
     },
     "quotations_query": {
       "description": "Set this to 1 to return quotations associated with detected entities",
-      "enum": [
-        0,
-        1
-      ],
+      "enum": [0, 1],
       "in": "query",
       "name": "quotations",
       "required": false,
@@ -1594,10 +1527,7 @@
     },
     "requireEntities_formData": {
       "description": "Set this to 1 to only report relations that contain at least one entity",
-      "enum": [
-        0,
-        1
-      ],
+      "enum": [0, 1],
       "in": "formData",
       "name": "requireEntities",
       "required": false,
@@ -1605,10 +1535,7 @@
     },
     "requireEntities_query": {
       "description": "Set this to 1 to only report relations that contain at least one entity",
-      "enum": [
-        0,
-        1
-      ],
+      "enum": [0, 1],
       "in": "query",
       "name": "requireEntities",
       "required": false,
@@ -1616,10 +1543,7 @@
     },
     "sentimentExcludeEntities_formData": {
       "description": "Set this to 1 to exclude entity name text from sentiment analysis (for example, do not analyze \"New\" in \"New York\")",
-      "enum": [
-        0,
-        1
-      ],
+      "enum": [0, 1],
       "in": "formData",
       "name": "sentimentExcludeEntities",
       "required": false,
@@ -1627,10 +1551,7 @@
     },
     "sentimentExcludeEntities_query": {
       "description": "Set this to 1 to exclude entity name text from sentiment analysis (for example, do not analyze \"New\" in \"New York\")",
-      "enum": [
-        0,
-        1
-      ],
+      "enum": [0, 1],
       "in": "query",
       "name": "sentimentExcludeEntities",
       "required": false,
@@ -1638,10 +1559,7 @@
     },
     "sentiment_formData": {
       "description": "Set this to 1 to return sentient information for each detected result<br><b>Incurs an additional API transaction</b>",
-      "enum": [
-        0,
-        1
-      ],
+      "enum": [0, 1],
       "in": "formData",
       "name": "sentiment",
       "required": false,
@@ -1649,10 +1567,7 @@
     },
     "sentiment_query": {
       "description": "Set this to 1 to return sentiment information for each detected result<br><b>Incurs an additional API transaction</b>",
-      "enum": [
-        0,
-        1
-      ],
+      "enum": [0, 1],
       "in": "query",
       "name": "sentiment",
       "required": false,
@@ -1660,10 +1575,7 @@
     },
     "showSourceText_formData": {
       "description": "Set this to 1 to include the original source text in the API response (default 0)",
-      "enum": [
-        0,
-        1
-      ],
+      "enum": [0, 1],
       "in": "formData",
       "name": "showSourceText",
       "required": false,
@@ -1671,10 +1583,7 @@
     },
     "showSourceText_query": {
       "description": "Set this to 1 to include the original source text in the API response (default 0)",
-      "enum": [
-        0,
-        1
-      ],
+      "enum": [0, 1],
       "in": "query",
       "name": "showSourceText",
       "required": false,
@@ -1712,10 +1621,7 @@
     },
     "structuredEntities_formData": {
       "description": "Set this to 0 to ignore structured entities, such as Quantity, EmailAddress, TwitterHandle, Hashtag, and IPAddress",
-      "enum": [
-        0,
-        1
-      ],
+      "enum": [0, 1],
       "in": "formData",
       "name": "structuredEntities",
       "required": false,
@@ -1723,10 +1629,7 @@
     },
     "structuredEntities_query": {
       "description": "Set this to 0 to ignore structured entities, such as Quantity, EmailAddress, TwitterHandle, Hashtag, and IPAddress",
-      "enum": [
-        0,
-        1
-      ],
+      "enum": [0, 1],
       "in": "query",
       "name": "structuredEntities",
       "required": false,
@@ -1790,10 +1693,7 @@
     },
     "useMetadata_formData": {
       "description": "Set this to 0 to ignore webpage metadata in the source text",
-      "enum": [
-        0,
-        1
-      ],
+      "enum": [0, 1],
       "in": "formData",
       "name": "useMetadata",
       "required": false,
@@ -1801,10 +1701,7 @@
     },
     "useMetadata_query": {
       "description": "Set this to 0 to ignore webpage metadata in the source text",
-      "enum": [
-        0,
-        1
-      ],
+      "enum": [0, 1],
       "in": "query",
       "name": "useMetadata",
       "required": false,
@@ -1861,9 +1758,7 @@
           }
         },
         "summary": "Extracts dates from an HTML document",
-        "tags": [
-          "Date Extraction"
-        ]
+        "tags": ["Date Extraction"]
       },
       "post": {
         "description": "Date extraction identifies dates that are mentioned in text. You can specify an anchor date to accurately interpret dates like \"next tuesday.\"",
@@ -1902,9 +1797,7 @@
           }
         },
         "summary": "Extracts dates from an HTML document",
-        "tags": [
-          "Date Extraction"
-        ]
+        "tags": ["Date Extraction"]
       }
     },
     "/html/HTMLGetAuthors": {
@@ -1936,9 +1829,7 @@
           }
         },
         "summary": "Retrieves author information from an HTML document",
-        "tags": [
-          "Authors"
-        ]
+        "tags": ["Authors"]
       },
       "post": {
         "description": "The HTMLGetAuthors call is utilized to extract author information contained within the specified web page. AlchemyLanguage will process the posted HTML document, looking for author information.",
@@ -1971,9 +1862,7 @@
           }
         },
         "summary": "Retrieves author information from an HTML document",
-        "tags": [
-          "Authors"
-        ]
+        "tags": ["Authors"]
       }
     },
     "/html/HTMLGetCombinedData": {
@@ -2011,9 +1900,7 @@
           }
         },
         "summary": "Analyzes HTML with multiple AlchemyLanguage operations",
-        "tags": [
-          "Combined Call"
-        ]
+        "tags": ["Combined Call"]
       },
       "post": {
         "description": "HTMLGetCombinedData lets you combine multiple AlchemyLanguage HTML operations into a single API call. Concept, keyword, entity, and taxonomy operations are performed by default if no 'extract' parameter is specified.<br><br>Any of the parameters that can be passed in the individual extract methods can be passed in a combined call, but they will apply to any applicable features that are specified in the <code>extract</code> parameter. For example, if you pass <code>knowledgeGraph=1</code> in a combined request for <code>concepts</code>, <code>entities</code>, <code>keywords</code>, and <code>relations</code>, you will add a total of 4 extra transactions to the request.",
@@ -2052,9 +1939,7 @@
           }
         },
         "summary": "Analyzes HTML with multiple AlchemyLanguage operations",
-        "tags": [
-          "Combined Call"
-        ]
+        "tags": ["Combined Call"]
       }
     },
     "/html/HTMLGetEmotion": {
@@ -2098,9 +1983,7 @@
           }
         },
         "summary": "Analyzes the emotion conveyed by text from an HTML document",
-        "tags": [
-          "Emotion Analysis"
-        ]
+        "tags": ["Emotion Analysis"]
       },
       "post": {
         "description": "Detects document-level emotion conveyed by the source text. Returns scores for anger, disgust, fear, joy, and sadness.",
@@ -2145,9 +2028,7 @@
           }
         },
         "summary": "Analyzes the emotion conveyed by text from an HTML document",
-        "tags": [
-          "Emotion Analysis"
-        ]
+        "tags": ["Emotion Analysis"]
       }
     },
     "/html/HTMLGetFeedLinks": {
@@ -2176,9 +2057,7 @@
           }
         },
         "summary": "Extracts RSS/Atom feeds from HTML",
-        "tags": [
-          "Feed Detection"
-        ]
+        "tags": ["Feed Detection"]
       },
       "post": {
         "description": "Identifies and returns RSS/ATOM feed links found in an HTML document.",
@@ -2208,9 +2087,7 @@
           }
         },
         "summary": "Extracts RSS/Atom feeds from HTML",
-        "tags": [
-          "Feed Detection"
-        ]
+        "tags": ["Feed Detection"]
       }
     },
     "/html/HTMLGetMicroformatData": {
@@ -2242,9 +2119,7 @@
           }
         },
         "summary": "Extracts microformat data from an HTML document",
-        "tags": [
-          "Microformats"
-        ]
+        "tags": ["Microformats"]
       },
       "post": {
         "description": "The HTMLGetMicroformatData call is utilized to extract microformat content from a posted HTML document. AlchemyLanguage will process the posted HTML document, looking for a variety of microformat data structures (hCards, geo, adr, etc.).",
@@ -2277,9 +2152,7 @@
           }
         },
         "summary": "Extracts microformat data from an HTML document",
-        "tags": [
-          "Microformats"
-        ]
+        "tags": ["Microformats"]
       }
     },
     "/html/HTMLGetPubDate": {
@@ -2311,9 +2184,7 @@
           }
         },
         "summary": "Retrieves publication date information from an HTML document",
-        "tags": [
-          "Publication Date"
-        ]
+        "tags": ["Publication Date"]
       },
       "post": {
         "description": "The HTMLGetPubDate call is utilized to extract publication date information contained within the specified web page. AlchemyLanguage will process the posted HTML document, looking for publication date information.",
@@ -2346,9 +2217,7 @@
           }
         },
         "summary": "Retrieves publication date information from an HTML document",
-        "tags": [
-          "Publication Date"
-        ]
+        "tags": ["Publication Date"]
       }
     },
     "/html/HTMLGetRankedConcepts": {
@@ -2401,9 +2270,7 @@
           }
         },
         "summary": "Returns concepts found in an HTML document",
-        "tags": [
-          "Concepts"
-        ]
+        "tags": ["Concepts"]
       },
       "post": {
         "description": "The HTMLGetRankedConcepts call is utilized to extract a relevancy-ranked list of concept tags for a posted HTML document. AlchemyLanguage will extract text from the posted HTML document structure (ignoring navigation links, advertisements, and other undesirable content), and perform concept tagging operations.",
@@ -2457,9 +2324,7 @@
           }
         },
         "summary": "Returns concepts found in an HTML document",
-        "tags": [
-          "Concepts"
-        ]
+        "tags": ["Concepts"]
       }
     },
     "/html/HTMLGetRankedKeywords": {
@@ -2512,9 +2377,7 @@
           }
         },
         "summary": "Extracts keywords from an HTML document",
-        "tags": [
-          "Keywords"
-        ]
+        "tags": ["Keywords"]
       },
       "post": {
         "description": "The HTMLGetRankedKeywords call is used to extract a relevancy-ranked list of topic keywords from a posted HTML document. AlchemyLanguage will extract text from the posted HTML document structure (ignoring navigation links, advertisements, and other undesirable content), and perform keyword extraction operations.",
@@ -2568,9 +2431,7 @@
           }
         },
         "summary": "Extracts keywords from an HTML document",
-        "tags": [
-          "Keywords"
-        ]
+        "tags": ["Keywords"]
       }
     },
     "/html/HTMLGetRankedNamedEntities": {
@@ -2638,9 +2499,7 @@
           }
         },
         "summary": "Extracts named entities (people, companies, etc) from an HTML document",
-        "tags": [
-          "Entities"
-        ]
+        "tags": ["Entities"]
       },
       "post": {
         "description": "The HTMLGetRankedNamedEntities call is used to extract a grouped, relevancy-ranked list of named entities (people, companies, organizations, etc.) from a posted HTML document. AlchemyLanguage will extract text from the posted HTML document (ignoring navigation links, advertisements, and other undesirable content), and perform entity extraction operations.",
@@ -2709,9 +2568,7 @@
           }
         },
         "summary": "Extracts named entities (people, companies, etc) from an HTML document",
-        "tags": [
-          "Entities"
-        ]
+        "tags": ["Entities"]
       }
     },
     "/html/HTMLGetRankedTaxonomy": {
@@ -2752,9 +2609,7 @@
           }
         },
         "summary": "Categorizes the content of an HTML document",
-        "tags": [
-          "Taxonomy"
-        ]
+        "tags": ["Taxonomy"]
       },
       "post": {
         "description": "The HTMLGetRankedTaxonomy call is used to categorize a posted HTML document. AlchemyLanguage will extract text and other important content from the posted HTML document structure and perform document categorization operations. AlchemyLanguage will extract text from the posted HTML document structure (ignoring navigation links, advertisements, and other undesirable content), and perform taxonomy classification operations.",
@@ -2796,9 +2651,7 @@
           }
         },
         "summary": "Categorizes the content of an HTML document",
-        "tags": [
-          "Taxonomy"
-        ]
+        "tags": ["Taxonomy"]
       }
     },
     "/html/HTMLGetRawText": {
@@ -2827,9 +2680,7 @@
           }
         },
         "summary": "Extracts all text from an HTML document",
-        "tags": [
-          "Text Extraction"
-        ]
+        "tags": ["Text Extraction"]
       },
       "post": {
         "description": "The HTMLGetRawText call is utilized to extract all text from a posted web page. AlchemyLanguage will extract text from the posted HTML document structure, including page navigation, advertisements, and other page content. To ignore this content, please use the HTMLGetText call.",
@@ -2859,9 +2710,7 @@
           }
         },
         "summary": "Extracts all text from an HTML document",
-        "tags": [
-          "Text Extraction"
-        ]
+        "tags": ["Text Extraction"]
       }
     },
     "/html/HTMLGetRelations": {
@@ -2935,9 +2784,7 @@
           }
         },
         "summary": "Extracts Subject-Action-Object relations from an HTML document",
-        "tags": [
-          "Relations"
-        ]
+        "tags": ["Relations"]
       },
       "post": {
         "description": "The HTMLGetRelations call is utilized to extract Subject-Action-Object relations from a posted HTML document. AlchemyLanguage will extract text from the HTML document structure (ignoring navigation links, advertisements, and other undesirable content), and perform relation extraction operations.",
@@ -3012,9 +2859,7 @@
           }
         },
         "summary": "Extracts Subject-Action-Object relations from an HTML document",
-        "tags": [
-          "Relations"
-        ]
+        "tags": ["Relations"]
       }
     },
     "/html/HTMLGetTargetedEmotion": {
@@ -3061,9 +2906,7 @@
           }
         },
         "summary": "Analyzes the emotion conveyed by target phrases from an HTML document",
-        "tags": [
-          "Emotion Analysis"
-        ]
+        "tags": ["Emotion Analysis"]
       },
       "post": {
         "description": "Searches the source text for specified target phrases and analyzes the emotions that they convey. Returns scores for anger, disgust, fear, joy, and sadness.",
@@ -3111,9 +2954,7 @@
           }
         },
         "summary": "Analyzes the emotion conveyed by target phrases from an HTML document",
-        "tags": [
-          "Emotion Analysis"
-        ]
+        "tags": ["Emotion Analysis"]
       }
     },
     "/html/HTMLGetTargetedSentiment": {
@@ -3160,9 +3001,7 @@
           }
         },
         "summary": "Returns sentiment information for specified phrases in an HTML document",
-        "tags": [
-          "Sentiment"
-        ]
+        "tags": ["Sentiment"]
       },
       "post": {
         "description": "The HTMLGetTargetedSentiment call is utilized to extract positive/negative sentiment targeted towards a specific user-specified target phrase inside the text of a posted HTML document. AlchemyLanguage will extract text from the posted HTML document structure (ignoring navigation links, advertisements, and other undesirable content), and perform sentiment analysis operations.",
@@ -3210,9 +3049,7 @@
           }
         },
         "summary": "Returns sentiment information for specified phrases in an HTML document",
-        "tags": [
-          "Sentiment"
-        ]
+        "tags": ["Sentiment"]
       }
     },
     "/html/HTMLGetText": {
@@ -3259,9 +3096,7 @@
           }
         },
         "summary": "Extracts primary text from an HTML document (avoids advertisements and other undesirable content)",
-        "tags": [
-          "Text Extraction"
-        ]
+        "tags": ["Text Extraction"]
       },
       "post": {
         "description": "The HTMLGetText call is utilized to extract the primary page / article text from a posted web page. AlchemyLanguage will extract text from the posted HTML document structure, ignoring page navigation, advertisements, and other undesirable page content.",
@@ -3309,9 +3144,7 @@
           }
         },
         "summary": "Extracts primary text from an HTML document (avoids advertisements and other undesirable content)",
-        "tags": [
-          "Text Extraction"
-        ]
+        "tags": ["Text Extraction"]
       }
     },
     "/html/HTMLGetTextSentiment": {
@@ -3355,9 +3188,7 @@
           }
         },
         "summary": "Returns sentiment information for an HTML document",
-        "tags": [
-          "Sentiment"
-        ]
+        "tags": ["Sentiment"]
       },
       "post": {
         "description": "The HTMLGetTextSentiment call is utilized to extract positive/negative sentiment from a posted HTML document. AlchemyLanguage will extract text from the posted HTML document structure (ignoring navigation links, advertisements, and other undesirable content), and perform sentiment analysis operations.",
@@ -3402,9 +3233,7 @@
           }
         },
         "summary": "Returns sentiment information for an HTML document",
-        "tags": [
-          "Sentiment"
-        ]
+        "tags": ["Sentiment"]
       }
     },
     "/html/HTMLGetTitle": {
@@ -3439,9 +3268,7 @@
           }
         },
         "summary": "Extracts title information from an HTML document",
-        "tags": [
-          "Title Extraction"
-        ]
+        "tags": ["Title Extraction"]
       },
       "post": {
         "description": "The HTMLGetTitle call is utilized to extract title information from a posted web page. The posted HTML document is processed, extracting any title information.",
@@ -3477,9 +3304,7 @@
           }
         },
         "summary": "Extracts title information from an HTML document",
-        "tags": [
-          "Title Extraction"
-        ]
+        "tags": ["Title Extraction"]
       }
     },
     "/html/HTMLGetTypedRelations": {
@@ -3517,9 +3342,7 @@
           }
         },
         "summary": "Identifies relations between entities found in HTML content",
-        "tags": [
-          "Typed Relations"
-        ]
+        "tags": ["Typed Relations"]
       },
       "post": {
         "description": "Identifies entities in text and returns different types of relations that exist between them. For example, the entities \"Oscar\" and \"Leonardo DiCaprio\" might be linked by an \"awardedTo\" relation. To tailor results to your domain, you can specify your own custom entities and relations with custom models in Watson Knowledge Studio",
@@ -3558,9 +3381,7 @@
           }
         },
         "summary": "Identifies relations between entities found in HTML content",
-        "tags": [
-          "Typed Relations"
-        ]
+        "tags": ["Typed Relations"]
       }
     },
     "/text/TextExtractDates": {
@@ -3598,9 +3419,7 @@
           }
         },
         "summary": "Extracts dates from text",
-        "tags": [
-          "Date Extraction"
-        ]
+        "tags": ["Date Extraction"]
       },
       "post": {
         "description": "Date extraction identifies dates that are mentioned in text. You can specify an anchor date to accurately interpret dates like \"next tuesday.\"",
@@ -3639,9 +3458,7 @@
           }
         },
         "summary": "Extracts dates from text",
-        "tags": [
-          "Date Extraction"
-        ]
+        "tags": ["Date Extraction"]
       }
     },
     "/text/TextGetCombinedData": {
@@ -3679,9 +3496,7 @@
           }
         },
         "summary": "Analyzes text with multiple AlchemyLanguage operations",
-        "tags": [
-          "Combined Call"
-        ]
+        "tags": ["Combined Call"]
       },
       "post": {
         "description": "TextGetCombinedData lets you combine multiple AlchemyLanguage text operations into a single API call. Concept, keyword, entity, and taxonomy operations are performed by default if no 'extract' parameter is specified.<br><br>Any of the parameters that can be passed in the individual extract methods can be passed in a combined call, but they will apply to any applicable features that are specified in the <code>extract</code> parameter. For example, if you pass <code>knowledgeGraph=1</code> in a combined request for <code>concepts</code>, <code>entities</code>, <code>keywords</code>, and <code>relations</code>, you will add a total of 4 extra transactions to the request.",
@@ -3720,9 +3535,7 @@
           }
         },
         "summary": "Analyzes text with multiple AlchemyLanguage operations",
-        "tags": [
-          "Combined Call"
-        ]
+        "tags": ["Combined Call"]
       }
     },
     "/text/TextGetEmotion": {
@@ -3757,9 +3570,7 @@
           }
         },
         "summary": "Analyzes the emotion conveyed by text",
-        "tags": [
-          "Emotion Analysis"
-        ],
+        "tags": ["Emotion Analysis"],
         "x-apih-advice": {
           "topJQueryAjaxParams": null,
           "topPayloadParams": [
@@ -3987,9 +3798,7 @@
           }
         },
         "summary": "Analyzes the emotion conveyed by text",
-        "tags": [
-          "Emotion Analysis"
-        ]
+        "tags": ["Emotion Analysis"]
       }
     },
     "/text/TextGetLanguage": {
@@ -4030,9 +3839,7 @@
           }
         },
         "summary": "Detects the language of a text document",
-        "tags": [
-          "Language"
-        ]
+        "tags": ["Language"]
       },
       "post": {
         "description": "TThe TextGetLanguage call is utilized to detect the language utilized within a posted text document.",
@@ -4074,9 +3881,7 @@
           }
         },
         "summary": "Detects the language of a text document",
-        "tags": [
-          "Language"
-        ]
+        "tags": ["Language"]
       }
     },
     "/text/TextGetRankedConcepts": {
@@ -4117,9 +3922,7 @@
           }
         },
         "summary": "Returns concepts found in a text document",
-        "tags": [
-          "Concepts"
-        ],
+        "tags": ["Concepts"],
         "x-apih-advice": {
           "topJQueryAjaxParams": null,
           "topPayloadParams": [
@@ -4309,9 +4112,7 @@
           }
         },
         "summary": "Returns concepts found in a text document",
-        "tags": [
-          "Concepts"
-        ]
+        "tags": ["Concepts"]
       }
     },
     "/text/TextGetRankedKeywords": {
@@ -4352,9 +4153,7 @@
           }
         },
         "summary": "Extracts keywords from a text document",
-        "tags": [
-          "Keywords"
-        ],
+        "tags": ["Keywords"],
         "x-apih-advice": {
           "topJQueryAjaxParams": null,
           "topPayloadParams": [
@@ -4544,9 +4343,7 @@
           }
         },
         "summary": "Extracts keywords from a text document",
-        "tags": [
-          "Keywords"
-        ]
+        "tags": ["Keywords"]
       }
     },
     "/text/TextGetRankedNamedEntities": {
@@ -4602,9 +4399,7 @@
           }
         },
         "summary": "Extracts named entities (people, companies, etc) from a text document",
-        "tags": [
-          "Entities"
-        ]
+        "tags": ["Entities"]
       },
       "post": {
         "description": "The TextGetRankedNamedEntities call is utilized to extract a grouped, ranked list of named entities (people, companies, organizations, etc.) from within a posted text document.",
@@ -4661,9 +4456,7 @@
           }
         },
         "summary": "Extracts named entities (people, companies, etc) from a text document",
-        "tags": [
-          "Entities"
-        ]
+        "tags": ["Entities"]
       }
     },
     "/text/TextGetRankedTaxonomy": {
@@ -4692,9 +4485,7 @@
           }
         },
         "summary": "Categorizes the content of a text document",
-        "tags": [
-          "Taxonomy"
-        ],
+        "tags": ["Taxonomy"],
         "x-apih-advice": {
           "topJQueryAjaxParams": null,
           "topPayloadParams": [
@@ -4872,9 +4663,7 @@
           }
         },
         "summary": "Categorizes the content of a text document",
-        "tags": [
-          "Taxonomy"
-        ]
+        "tags": ["Taxonomy"]
       }
     },
     "/text/TextGetRelations": {
@@ -4936,9 +4725,7 @@
           }
         },
         "summary": "Extracts Subject-Action-Object relations from a text document",
-        "tags": [
-          "Relations"
-        ]
+        "tags": ["Relations"]
       },
       "post": {
         "description": "The TextGetRelations call is utilized to extract Subject-Action-Object relations from a given text document.",
@@ -5001,9 +4788,7 @@
           }
         },
         "summary": "Extracts Subject-Action-Object relations from a text document",
-        "tags": [
-          "Relations"
-        ]
+        "tags": ["Relations"]
       }
     },
     "/text/TextGetTargetedEmotion": {
@@ -5041,9 +4826,7 @@
           }
         },
         "summary": "Analyzes the emotion conveyed by target phrases from text",
-        "tags": [
-          "Emotion Analysis"
-        ]
+        "tags": ["Emotion Analysis"]
       },
       "post": {
         "description": "Searches the source text for specified target phrases and analyzes the emotions that they convey. Returns scores for anger, disgust, fear, joy, and sadness.",
@@ -5082,9 +4865,7 @@
           }
         },
         "summary": "Analyzes the emotion conveyed by target phrases from text",
-        "tags": [
-          "Emotion Analysis"
-        ]
+        "tags": ["Emotion Analysis"]
       }
     },
     "/text/TextGetTargetedSentiment": {
@@ -5119,9 +4900,7 @@
           }
         },
         "summary": "Returns sentiment information for specified phrases in a text document",
-        "tags": [
-          "Sentiment"
-        ],
+        "tags": ["Sentiment"],
         "x-apih-advice": {
           "topJQueryAjaxParams": null,
           "topPayloadParams": [
@@ -5257,9 +5036,7 @@
           }
         },
         "summary": "Returns sentiment information for specified phrases in a text document",
-        "tags": [
-          "Sentiment"
-        ]
+        "tags": ["Sentiment"]
       }
     },
     "/text/TextGetTextSentiment": {
@@ -5291,9 +5068,7 @@
           }
         },
         "summary": "Returns sentiment information for a text document",
-        "tags": [
-          "Sentiment"
-        ],
+        "tags": ["Sentiment"],
         "x-apih-advice": {
           "topJQueryAjaxParams": null,
           "topPayloadParams": [
@@ -5569,9 +5344,7 @@
           }
         },
         "summary": "Returns sentiment information for a text document",
-        "tags": [
-          "Sentiment"
-        ]
+        "tags": ["Sentiment"]
       }
     },
     "/text/TextGetTypedRelations": {
@@ -5606,9 +5379,7 @@
           }
         },
         "summary": "Identifies relations between entities found in text",
-        "tags": [
-          "Typed Relations"
-        ]
+        "tags": ["Typed Relations"]
       },
       "post": {
         "description": "Identifies entities in text and returns different types of relations that exist between them. For example, the entities \"Oscar\" and \"Leonardo DiCaprio\" might be linked by an \"awardedTo\" relation. To tailor results to your domain, you can specify your own custom entities and relations with custom models in Watson Knowledge Studio",
@@ -5644,9 +5415,7 @@
           }
         },
         "summary": "Identifies relations between entities found in text",
-        "tags": [
-          "Typed Relations"
-        ]
+        "tags": ["Typed Relations"]
       }
     },
     "/url/URLExtractDates": {
@@ -5681,9 +5450,7 @@
           }
         },
         "summary": "Extracts dates from the text on a webpage",
-        "tags": [
-          "Date Extraction"
-        ]
+        "tags": ["Date Extraction"]
       },
       "post": {
         "description": "Date extraction identifies dates that are mentioned in text. You can specify an anchor date to accurately interpret dates like \"next tuesday.\"",
@@ -5719,9 +5486,7 @@
           }
         },
         "summary": "Extracts dates from the text on a webpage",
-        "tags": [
-          "Date Extraction"
-        ]
+        "tags": ["Date Extraction"]
       }
     },
     "/url/URLGetAuthors": {
@@ -5750,9 +5515,7 @@
           }
         },
         "summary": "Retrieves author information from a web page",
-        "tags": [
-          "Authors"
-        ],
+        "tags": ["Authors"],
         "x-apih-advice": {
           "topJQueryAjaxParams": null,
           "topPayloadParams": [
@@ -5824,9 +5587,7 @@
           }
         },
         "summary": "Retrieves author information from a web page",
-        "tags": [
-          "Authors"
-        ]
+        "tags": ["Authors"]
       }
     },
     "/url/URLGetCombinedData": {
@@ -5861,9 +5622,7 @@
           }
         },
         "summary": "Analyzes a web page with multiple AlchemyLanguage operations",
-        "tags": [
-          "Combined Call"
-        ],
+        "tags": ["Combined Call"],
         "x-apih-advice": {
           "topJQueryAjaxParams": null,
           "topPayloadParams": null,
@@ -6026,9 +5785,7 @@
           }
         },
         "summary": "Analyzes a web page with multiple AlchemyLanguage operations",
-        "tags": [
-          "Combined Call"
-        ]
+        "tags": ["Combined Call"]
       }
     },
     "/url/URLGetEmotion": {
@@ -6069,9 +5826,7 @@
           }
         },
         "summary": "Analyzes the emotion conveyed by text from webpage",
-        "tags": [
-          "Emotion Analysis"
-        ],
+        "tags": ["Emotion Analysis"],
         "x-apih-advice": {
           "topJQueryAjaxParams": null,
           "topPayloadParams": [
@@ -6215,9 +5970,7 @@
           }
         },
         "summary": "Analyzes the emotion conveyed by text from a webpage",
-        "tags": [
-          "Emotion Analysis"
-        ]
+        "tags": ["Emotion Analysis"]
       }
     },
     "/url/URLGetFeedLinks": {
@@ -6246,9 +5999,7 @@
           }
         },
         "summary": "Extracts RSS/Atom feeds from a webpage",
-        "tags": [
-          "Feed Detection"
-        ]
+        "tags": ["Feed Detection"]
       },
       "post": {
         "description": "Identifies and returns RSS/ATOM feed links found on a webpage.",
@@ -6278,9 +6029,7 @@
           }
         },
         "summary": "Extracts RSS/Atom feeds from a webpage",
-        "tags": [
-          "Feed Detection"
-        ]
+        "tags": ["Feed Detection"]
       }
     },
     "/url/URLGetLanguage": {
@@ -6318,9 +6067,7 @@
           }
         },
         "summary": "Detects the language of a web page",
-        "tags": [
-          "Language"
-        ]
+        "tags": ["Language"]
       },
       "post": {
         "description": "The URLGetLanguage call is utilized to detect the language utilized within a given web page. AlchemyLanguage will download the requested URL, extracting text from the HTML document structure (ignoring navigation links, advertisements, and other undesirable content), and perform language detection operations.",
@@ -6359,9 +6106,7 @@
           }
         },
         "summary": "Detects the language of a web page",
-        "tags": [
-          "Language"
-        ]
+        "tags": ["Language"]
       }
     },
     "/url/URLGetMicroformatData": {
@@ -6390,9 +6135,7 @@
           }
         },
         "summary": "Extracts microformat data from a web page",
-        "tags": [
-          "Microformats"
-        ]
+        "tags": ["Microformats"]
       },
       "post": {
         "description": "The URLGetMicroformatData call is utilized to extract structured microformats data from a given web page. AlchemyLanguage will retrieve the requested URL, process the retrieved HTML document, and look for a variety of microformat data structures (hCards, geo, adr, etc.).",
@@ -6422,9 +6165,7 @@
           }
         },
         "summary": "Extracts microformat data from a web page",
-        "tags": [
-          "Microformats"
-        ]
+        "tags": ["Microformats"]
       }
     },
     "/url/URLGetPubDate": {
@@ -6453,9 +6194,7 @@
           }
         },
         "summary": "Retrieves publication date information from a web page",
-        "tags": [
-          "Publication Date"
-        ]
+        "tags": ["Publication Date"]
       },
       "post": {
         "description": "The URLGetPubDate call is utilized to extract publication date information contained within the specified web page. contained within the specified web page. AlchemyLanguage will download the requested URL, process the retrieved HTML document, looking for publication date information.",
@@ -6485,9 +6224,7 @@
           }
         },
         "summary": "Retrieves publication date information from a web page",
-        "tags": [
-          "Publication Date"
-        ]
+        "tags": ["Publication Date"]
       }
     },
     "/url/URLGetRankedConcepts": {
@@ -6537,9 +6274,7 @@
           }
         },
         "summary": "Returns concepts found on a web page",
-        "tags": [
-          "Concepts"
-        ]
+        "tags": ["Concepts"]
       },
       "post": {
         "description": "The URLGetRankedConcepts call is utilized to extract a relevancy-ranked list of concept tags for a given web page. AlchemyLanguage will download the requested URL, extracting text from the HTML document structure (ignoring navigation links, advertisements, and other undesirable content), and perform concept tagging operations.",
@@ -6590,9 +6325,7 @@
           }
         },
         "summary": "Returns concepts found on a web page",
-        "tags": [
-          "Concepts"
-        ]
+        "tags": ["Concepts"]
       }
     },
     "/url/URLGetRankedKeywords": {
@@ -6642,9 +6375,7 @@
           }
         },
         "summary": "Extracts keywords from a web page",
-        "tags": [
-          "Keywords"
-        ],
+        "tags": ["Keywords"],
         "x-apih-advice": {
           "topJQueryAjaxParams": null,
           "topPayloadParams": [
@@ -6779,9 +6510,7 @@
           }
         },
         "summary": "Extracts keywords from a web page",
-        "tags": [
-          "Keywords"
-        ]
+        "tags": ["Keywords"]
       }
     },
     "/url/URLGetRankedNamedEntities": {
@@ -6846,9 +6575,7 @@
           }
         },
         "summary": "Extracts named entities (people, companies, etc) from a web page",
-        "tags": [
-          "Entities"
-        ],
+        "tags": ["Entities"],
         "x-apih-advice": {
           "topJQueryAjaxParams": null,
           "topPayloadParams": [
@@ -7013,9 +6740,7 @@
           }
         },
         "summary": "Extracts named entities (people, companies, etc) from a web page",
-        "tags": [
-          "Entities"
-        ]
+        "tags": ["Entities"]
       }
     },
     "/url/URLGetRankedTaxonomy": {
@@ -7053,9 +6778,7 @@
           }
         },
         "summary": "Categorizes the content of a web page",
-        "tags": [
-          "Taxonomy"
-        ],
+        "tags": ["Taxonomy"],
         "x-apih-advice": {
           "topJQueryAjaxParams": null,
           "topPayloadParams": [
@@ -7133,9 +6856,7 @@
           }
         },
         "summary": "Categorizes the content of a web page",
-        "tags": [
-          "Taxonomy"
-        ]
+        "tags": ["Taxonomy"]
       }
     },
     "/url/URLGetRawText": {
@@ -7164,9 +6885,7 @@
           }
         },
         "summary": "Extracts all text from a web page",
-        "tags": [
-          "Text Extraction"
-        ]
+        "tags": ["Text Extraction"]
       },
       "post": {
         "description": "The URLGetRawText call is utilized to extract all text from a web page. AlchemyLanguage will download the requested URL, extract text from the HTML document structure, including page navigation, advertisements, and other page content. To ignore this content, please use the URLGetText call.",
@@ -7196,9 +6915,7 @@
           }
         },
         "summary": "Extracts all text from a web page",
-        "tags": [
-          "Text Extraction"
-        ]
+        "tags": ["Text Extraction"]
       }
     },
     "/url/URLGetRelations": {
@@ -7269,9 +6986,7 @@
           }
         },
         "summary": "Extracts Subject-Action-Object relations from a web page",
-        "tags": [
-          "Relations"
-        ]
+        "tags": ["Relations"]
       },
       "post": {
         "description": "The URLGetRelations call is utilized to extract Subject-Action-Object relations from a given web page. AlchemyLanguage will download the requested URL, extracting text from the HTML document structure (ignoring navigation links, advertisements, and other undesirable content), and perform relation extraction operations.",
@@ -7343,9 +7058,7 @@
           }
         },
         "summary": "Extracts Subject-Action-Object relations from a web page",
-        "tags": [
-          "Relations"
-        ]
+        "tags": ["Relations"]
       }
     },
     "/url/URLGetTargetedEmotion": {
@@ -7389,9 +7102,7 @@
           }
         },
         "summary": "Analyzes the emotion conveyed by target phrases from a webpage",
-        "tags": [
-          "Emotion Analysis"
-        ]
+        "tags": ["Emotion Analysis"]
       },
       "post": {
         "description": "Searches the source text for specified target phrases and analyzes the emotions that they convey. Returns scores for anger, disgust, fear, joy, and sadness.",
@@ -7436,9 +7147,7 @@
           }
         },
         "summary": "Analyzes the emotion conveyed by target phrases from a webpage",
-        "tags": [
-          "Emotion Analysis"
-        ]
+        "tags": ["Emotion Analysis"]
       }
     },
     "/url/URLGetTargetedSentiment": {
@@ -7482,9 +7191,7 @@
           }
         },
         "summary": "Returns sentiment information for specified phrases on a web page",
-        "tags": [
-          "Sentiment"
-        ]
+        "tags": ["Sentiment"]
       },
       "post": {
         "description": "The URLGetTargetedSentiment call is utilized to extract positive / negative sentiment targeted towards a specific user-specified target phrase inside the text of a given web page. AlchemyLanguage will download the requested URL, extracting text from the HTML document structure (ignoring navigation links, advertisements, and other undesirable content), and perform sentiment extraction operations.",
@@ -7529,9 +7236,7 @@
           }
         },
         "summary": "Returns sentiment information for specified phrases on a web page",
-        "tags": [
-          "Sentiment"
-        ]
+        "tags": ["Sentiment"]
       }
     },
     "/url/URLGetText": {
@@ -7575,9 +7280,7 @@
           }
         },
         "summary": "Extracts primary text from a web page (avoids advertisements and other undesirable content)",
-        "tags": [
-          "Text Extraction"
-        ],
+        "tags": ["Text Extraction"],
         "x-apih-advice": {
           "topJQueryAjaxParams": null,
           "topPayloadParams": null,
@@ -7629,9 +7332,7 @@
           }
         },
         "summary": "Extracts primary text from a web page (avoids advertisements and other undesirable content)",
-        "tags": [
-          "Text Extraction"
-        ]
+        "tags": ["Text Extraction"]
       }
     },
     "/url/URLGetTextSentiment": {
@@ -7672,9 +7373,7 @@
           }
         },
         "summary": "Returns sentiment information for a web page",
-        "tags": [
-          "Sentiment"
-        ],
+        "tags": ["Sentiment"],
         "x-apih-advice": {
           "topJQueryAjaxParams": null,
           "topPayloadParams": [
@@ -7816,9 +7515,7 @@
           }
         },
         "summary": "Returns sentiment information for a web page",
-        "tags": [
-          "Sentiment"
-        ]
+        "tags": ["Sentiment"]
       }
     },
     "/url/URLGetTitle": {
@@ -7850,9 +7547,7 @@
           }
         },
         "summary": "Extracts title information from a web page",
-        "tags": [
-          "Title Extraction"
-        ]
+        "tags": ["Title Extraction"]
       },
       "post": {
         "description": "The URLGetTitle call is utilized to extract title information from a web page. The requested URL is downloaded, and the retrieved HTML document is processed, extracting any title information.",
@@ -7885,9 +7580,7 @@
           }
         },
         "summary": "Extracts title information from a web page",
-        "tags": [
-          "Title Extraction"
-        ]
+        "tags": ["Title Extraction"]
       }
     },
     "/url/URLGetTypedRelations": {
@@ -7919,9 +7612,7 @@
           }
         },
         "summary": "Identifies relations between entities found in text from a webpage",
-        "tags": [
-          "Typed Relations"
-        ]
+        "tags": ["Typed Relations"]
       },
       "post": {
         "description": "Identifies entities in the text from a webpage and returns different types of relations that exist between them. For example, the entities \"Oscar\" and \"Leonardo DiCaprio\" might be linked by an \"awardedTo\" relation. To tailor results to your domain, you can specify your own custom entities and relations with custom models in Watson Knowledge Studio",
@@ -7954,19 +7645,12 @@
           }
         },
         "summary": "Identifies relations between entities found in text from a webpage",
-        "tags": [
-          "Typed Relations"
-        ]
+        "tags": ["Typed Relations"]
       }
     }
   },
-  "produces": [
-    "application/json",
-    "application/xml"
-  ],
-  "schemes": [
-    "https"
-  ],
+  "produces": ["application/json", "application/xml"],
+  "schemes": ["https"],
   "swagger": "2.0",
   "x-apih-ghusage": {
     "count": 0,


### PR DESCRIPTION
Currently headers found inside a given method's parameters only populate with an example value of "SOME_' + (param.type||param.schema.type).toUpperCase() + '_VALUE". This PR generates an example value for headers found in the parameter using some properties found in the parameter object. Additionally, this PR also uses the "example" property in the parameter object (if available) to generate an example value. 