### PR TITLE
Add support for multipart/form-data snippet generation

### DIFF
--- a/openapi-to-har.js
+++ b/openapi-to-har.js
@@ -104,21 +104,43 @@ const getPayload = function (openApi, path, method) {
   }
 
   if (
-    openApi.paths[path][method].requestBody &&
-    openApi.paths[path][method].requestBody.content &&
-    openApi.paths[path][method].requestBody.content['application/json'] &&
-    openApi.paths[path][method].requestBody.content['application/json'].schema
-  ) {
-    const sample = OpenAPISampler.sample(
-      openApi.paths[path][method].requestBody.content['application/json']
-        .schema,
-      { skipReadOnly: true },
-      openApi
-    );
-    return {
-      mimeType: 'application/json',
-      text: JSON.stringify(sample),
-    };
+     openApi.paths[path][method].requestBody &&
+     openApi.paths[path][method].requestBody.content
+   ) {
+     if (openApi.paths[path][method].requestBody.content['application/json'] &&
+       openApi.paths[path][method].requestBody.content['application/json'].schema
+     ) {
+       const sample = OpenAPISampler.sample(
+         openApi.paths[path][method].requestBody.content['application/json']
+           .schema,
+         { skipReadOnly: true },
+         openApi
+       );
+       return {
+         mimeType: 'application/json',
+         text: JSON.stringify(sample)
+       };
+     }
+
+     if (openApi.paths[path][method].requestBody.content['multipart/form-data'] &&
+       openApi.paths[path][method].requestBody.content['multipart/form-data'].schema
+     ) {
+       const sample = OpenAPISampler.sample(openApi.paths[path][method].requestBody.content['multipart/form-data']
+           .schema,
+         {skipReadOnly: true},
+         openApi
+       );
+
+       if (sample === undefined) return null;
+
+       const params = [];
+       Object.keys(sample).map(key => params.push({'name': key, 'value': sample[key]}));
+
+       return {
+         mimeType: 'multipart/form-data',
+         params: params,
+       };
+     }
   }
   return null;
 };

--- a/test/form_data_example.json
+++ b/test/form_data_example.json
@@ -1,0 +1,76 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "version": "1.0.0",
+    "title": "Swagger Petstore",
+    "description": "A sample API that uses a petstore as an example to demonstrate features in the OpenAPI 3.0 specification",
+    "termsOfService": "http://swagger.io/terms/",
+    "contact": {
+      "name": "Swagger API Team",
+      "email": "apiteam@swagger.io",
+      "url": "http://swagger.io"
+    },
+    "license": {
+      "name": "Apache 2.0",
+      "url": "https://www.apache.org/licenses/LICENSE-2.0.html"
+    }
+  },
+  "servers": [
+    {
+      "url": "http://petstore.swagger.io/api"
+    }
+  ],
+  "paths": {
+    "/pets": {
+      "patch": {
+        "description": "Creates a new pet in the store.  Duplicates are allowed",
+        "operationId": "addPet",
+        "requestBody": {
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "$ref": "#/components/schemas/ModifyPet"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "pet response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Pet"
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "unexpected error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "ModifyPet": {
+        "properties": {
+          "pet[name]": {
+            "type": "string"
+          },
+          "pet[tag]": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  }
+}

--- a/test/test.js
+++ b/test/test.js
@@ -12,6 +12,7 @@ const PetStoreOpenAPI = require('./petstore_swagger.json');
 const PetStoreOpenAPI3 = require('./petstore_oas.json');
 const ParameterSchemaReferenceAPI = require('./parameter_schema_reference');
 const ParameterExampleReferenceAPI = require('./parameter_example_swagger.json');
+const FormDataExampleReferenceAPI = require('./form_data_example.json');
 
 test('Getting snippets should not result in error or undefined', function (t) {
   t.plan(1);
@@ -194,5 +195,18 @@ test('Testing the case when an example is provided, use the provided example val
   const snippet = result.snippets[0].content;
   t.true(/ {tags: 'dog,cat', limit: '10'}/.test(snippet));
   t.false(/SOME_INTEGER_VALUE/.test(snippet));
+  t.end();
+});
+
+test('Generate snippet with multipart/form-data', function (t) {
+  const result = OpenAPISnippets.getEndpointSnippets(
+    FormDataExampleReferenceAPI,
+    '/pets',
+    'patch',
+    ['node_request']
+  );
+  const snippet = result.snippets[0].content;
+  t.true(/boundary=---011000010111000001101001/.test(snippet));
+  t.true(/formData: {'pet\[name\]': 'string', 'pet\[tag\]': 'string'}/.test(snippet));
   t.end();
 });


### PR DESCRIPTION
Add support for generating code snippets for requests with content-type `multipart/form-data`.

Want to get any feedback on improving this code before I submit it to the official library