### PR TITLE
Fix bug when generating multipart/form-data requests

### DIFF
--- a/openapi-to-har.js
+++ b/openapi-to-har.js
@@ -147,10 +147,14 @@ const getPayloads = function (openApi, path, method) {
           });
         } else if (type === 'multipart/form-data') {
           if (sample !== undefined) {
-            const params = Object.keys(sample).reduce(
-              (acc, key) => acc.concat([{ name: key, value: sample[key] }]),
-              []
-            );
+            const params = [];
+            Object.keys(sample).forEach((key) => {
+              let value = sample[key];
+              if (typeof sample[key] !== 'string') {
+                value = JSON.stringify(sample[key]);
+              }
+              params.push({ name: key, value: value });
+            });
             payloads.push({
               mimeType: type,
               params: params,

--- a/test/form_data_example.json
+++ b/test/form_data_example.json
@@ -57,6 +57,80 @@
           }
         }
       }
+    },
+    "/pets/{id}/updatetags": {
+      "patch": {
+        "description": "Updates tags on a specific pet",
+        "operationId": "updatePetTags",
+        "requestBody": {
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateTags"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "pet response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Pet"
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "unexpected error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/pets/{id}/feedingschedule": {
+      "patch": {
+        "description": "Updates feeding schedule for specific pet",
+        "operationId": "updatePetFeedingSchedule",
+        "requestBody": {
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateFeedingSchedule"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "pet response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Pet"
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "unexpected error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
     }
   },
   "components": {
@@ -68,6 +142,31 @@
           },
           "pet[tag]": {
             "type": "string"
+          }
+        }
+      },
+      "UpdateTags": {
+        "properties": {
+          "pet[tags]": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "UpdateFeedingSchedule": {
+        "properties": {
+          "pet[feedingSchedule]": {
+            "type": "object",
+            "properties": {
+              "time": {
+                "type": "string"
+              },
+              "food": {
+                "type": "string"
+              }
+            }
           }
         }
       }

--- a/test/test.js
+++ b/test/test.js
@@ -215,6 +215,36 @@ test('Generate snippet with multipart/form-data', function (t) {
   t.end();
 });
 
+test('Generate snippet with multipart/form-data with array', function (t) {
+  const result = OpenAPISnippets.getEndpointSnippets(
+    FormDataExampleReferenceAPI,
+    '/pets/{id}/updatetags',
+    'patch',
+    ['node_request']
+  );
+  const snippet = result.snippets[0].content;
+  t.true(/boundary=---011000010111000001101001/.test(snippet));
+  t.true(/formData: {'pet\[tags\]': '\["string"\]'}/.test(snippet));
+  t.end();
+});
+
+test('Generate snippet with multipart/form-data with object', function (t) {
+  const result = OpenAPISnippets.getEndpointSnippets(
+    FormDataExampleReferenceAPI,
+    '/pets/{id}/feedingschedule',
+    'patch',
+    ['node_request']
+  );
+  const snippet = result.snippets[0].content;
+  t.true(/boundary=---011000010111000001101001/.test(snippet));
+  t.true(
+    /formData: {'pet\[feedingSchedule\]': '{"time":"string","food":"string"}'}/.test(
+      snippet
+    )
+  );
+  t.end();
+});
+
 test('Generate snippets with multiple content types', function (t) {
   const result = OpenAPISnippets.getEndpointSnippets(
     MultipleRequestContentReferenceAPI,


### PR DESCRIPTION
`multipart/form-data` requests work for simple requests where values are of type `string`. However, if the values are richer data types like `array` or `object` the generation will fail with error:
```
  source.on('error', function() {});
         ^

TypeError: source.on is not a function
    at Function.DelayedStream.create (~/src/openapi-snippet/node_modules/delayed-stream/lib/delayed_stream.js:33:10)
    at FormData.CombinedStream.append (~/src/openapi-snippet/node_modules/combined-stream/lib/combined_stream.js:45:37)
    at FormData.append (~/src/openapi-snippet/node_modules/form-data/lib/form_data.js:68:3)
    at ~/src/openapi-snippet/node_modules/httpsnippet/src/index.js:111:16
    at Array.forEach (<anonymous>)
    at HTTPSnippet.prepare (~/src/openapi-snippet/node_modules/httpsnippet/src/index.js:110:33)
    at ~//src/openapi-snippet/node_modules/httpsnippet/src/index.js:48:31
    at validate (~/src/openapi-snippet/node_modules/har-validator/lib/async.js:29:12)
    at Object.exports.request (~/src/openapi-snippet/node_modules/har-validator/lib/async.js:96:10)
    at ~/src/openapi-snippet/node_modules/httpsnippet/src/index.js:43:14
```

This comment: https://github.com/request/request/issues/2366#issuecomment-292110690 confirms that the value must be of type string, Buffer or Stream.

Changes:
- Before appending {name, value} to params, stringify objects or arrays for `multipart/form-data`
- Add additional tests to verify that new behavior works and generates the correct snippets