### PR TITLE
Parse multiple servers from Open API spec

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,8 +30,6 @@ const getEndpointSnippets = function (openApi, path, method, targets, values) {
 
   const hars = OpenAPIToHar.getEndpoint(openApi, path, method, values);
 
-  console.log(hars);
-
   let results = [];
   for (const har of hars) {
     const snippets = [];

--- a/test/test.js
+++ b/test/test.js
@@ -67,8 +67,8 @@ test('Getting snippets for endpoint should contain body', function (t) {
     'post',
     ['node_request']
   );
-  t.true(/body/.test(result.snippets[0].content));
-  t.true(/subPage/.test(result.snippets[0].content));
+  t.true(/body/.test(result[0].snippets[0].content));
+  t.true(/subPage/.test(result[0].snippets[0].content));
 });
 
 test('Getting snippets from OpenAPI 3.0.x should work', function (t) {
@@ -85,19 +85,19 @@ test('Getting snippets from OpenAPI 3.0.x should work', function (t) {
 
 test('Testing server overrides', function (t) {
   t.plan(12);
-  const result = OpenAPISnippets.getSnippets(PetStoreOpenAPI3, ['c_libcurl']);
-  t.equal(result[0].url, 'https://method-override.example.com/pets');
-  t.match(result[0].snippets[0].content, /.*method-override.example.com.*/);
-  t.doesNotMatch(result[0].snippets[0].content, /.*petstore.swagger.io.*/);
-  t.equal(result[1].url, 'http://petstore.swagger.io/api/pets/{id}');
-  t.match(result[1].snippets[0].content, /.*petstore.swagger.io.*/);
-  t.doesNotMatch(result[1].snippets[0].content, /.*example.com.*/);
-  t.equal(result[2].url, 'https://path-override.example.com/pets');
-  t.match(result[2].snippets[0].content, /.*path-override.example.com.*/);
-  t.doesNotMatch(result[2].snippets[0].content, /.*petstore.swagger.io.*/);
-  t.equal(result[3].url, 'http://petstore.swagger.io/api/pets/{id}');
-  t.match(result[3].snippets[0].content, /.*petstore.swagger.io.*/);
-  t.doesNotMatch(result[3].snippets[0].content, /.*example.com.*/);
+  let result = OpenAPISnippets.getSnippets(PetStoreOpenAPI3, ['c_libcurl']);
+  t.equal(result[0][0].url, 'https://method-override.example.com/pets');
+  t.match(result[0][0].snippets[0].content, /.*method-override.example.com.*/);
+  t.doesNotMatch(result[0][0].snippets[0].content, /.*petstore.swagger.io.*/);
+  t.equal(result[1][0].url, 'http://petstore.swagger.io/api/pets/{id}');
+  t.match(result[1][0].snippets[0].content, /.*petstore.swagger.io.*/);
+  t.doesNotMatch(result[1][0].snippets[0].content, /.*example.com.*/);
+  t.equal(result[2][0].url, 'https://path-override.example.com/pets');
+  t.match(result[2][0].snippets[0].content, /.*path-override.example.com.*/);
+  t.doesNotMatch(result[2][0].snippets[0].content, /.*petstore.swagger.io.*/);
+  t.equal(result[3][0].url, 'http://petstore.swagger.io/api/pets/{id}');
+  t.match(result[3][0].snippets[0].content, /.*petstore.swagger.io.*/);
+  t.doesNotMatch(result[3][0].snippets[0].content, /.*example.com.*/);
 });
 
 test('Testing optionally provided parameter values', function (t) {
@@ -113,8 +113,9 @@ test('Testing optionally provided parameter values', function (t) {
       'not-a-query-param': 'foo',
     }
   );
-  t.true(/5000/.test(result.snippets[0].content));
-  t.false(/not-a-query-param/.test(result.snippets[0].content));
+  console.log(result);
+  t.true(/5000/.test(result[0].snippets[0].content));
+  t.false(/not-a-query-param/.test(result[0].snippets[0].content));
 });
 
 test('Testing the case when default is present but a value is provided, use the provided value', function (t) {
@@ -129,8 +130,8 @@ test('Testing the case when default is present but a value is provided, use the 
       filter: 'assigned',
     }
   );
-  t.true(/assigned/.test(result.snippets[0].content));
-  t.false(/all/.test(result.snippets[0].content)); // The default value of `filter` is `all`
+  t.true(/assigned/.test(result[0].snippets[0].content));
+  t.false(/all/.test(result[0].snippets[0].content)); // The default value of `filter` is `all`
 });
 
 test('Testing the case when default is present but no value is provided, use the default', function (t) {
@@ -142,8 +143,8 @@ test('Testing the case when default is present but no value is provided, use the
     'get',
     ['node_request']
   );
-  t.false(/assigned/.test(result.snippets[0].content));
-  t.true(/all/.test(result.snippets[0].content)); // The default value of `filter` is `all`
+  t.false(/assigned/.test(result[0].snippets[0].content));
+  t.true(/all/.test(result[0].snippets[0].content)); // The default value of `filter` is `all`
 });
 
 test('Referenced query parameters should be resolved', function (t) {
@@ -153,7 +154,7 @@ test('Referenced query parameters should be resolved', function (t) {
     'get',
     ['node_request']
   );
-  const snippet = result.snippets[0].content;
+  const snippet = result[0].snippets[0].content;
   t.true(/apikey/.test(snippet));
   t.true(/showSourceText/.test(snippet));
   t.end();
@@ -166,7 +167,7 @@ test('Resolve samples from nested examples', function (t) {
     'post',
     ['node_request']
   );
-  const snippet = result.snippets[0].content;
+  const snippet = result[0].snippets[0].content;
   t.true(/username.*John78\'/.test(snippet));
   t.true(/email.*john.smith@example.com\'/.test(snippet));
   t.true(/phone.*\+1\-202\-555\-0192/.test(snippet));
@@ -181,7 +182,7 @@ test('Parameters that are Schema References Are Dereferenced', function (t) {
     'post',
     ['node_request']
   );
-  const snippet = result.snippets[0].content;
+  const snippet = result[0].snippets[0].content;
   t.true(/pet: 'SOME_OBJECT_VALUE'/.test(snippet));
   t.end();
 });
@@ -194,7 +195,7 @@ test('Testing the case when an example is provided, use the provided example val
     'get',
     ['node_request']
   );
-  const snippet = result.snippets[0].content;
+  const snippet = result[0].snippets[0].content;
   t.true(/ {tags: 'dog,cat', limit: '10'}/.test(snippet));
   t.false(/SOME_INTEGER_VALUE/.test(snippet));
   t.end();
@@ -207,7 +208,7 @@ test('Generate snippet with multipart/form-data', function (t) {
     'patch',
     ['node_request']
   );
-  const snippet = result.snippets[0].content;
+  const snippet = result[0].snippets[0].content;
   t.true(/boundary=---011000010111000001101001/.test(snippet));
   t.true(
     /formData: {'pet\[name\]': 'string', 'pet\[tag\]': 'string'}/.test(snippet)
@@ -222,7 +223,7 @@ test('Generate snippet with multipart/form-data with array', function (t) {
     'patch',
     ['node_request']
   );
-  const snippet = result.snippets[0].content;
+  const snippet = result[0].snippets[0].content;
   t.true(/boundary=---011000010111000001101001/.test(snippet));
   t.true(/formData: {'pet\[tags\]': '\["string"\]'}/.test(snippet));
   t.end();
@@ -235,7 +236,7 @@ test('Generate snippet with multipart/form-data with object', function (t) {
     'patch',
     ['node_request']
   );
-  const snippet = result.snippets[0].content;
+  const snippet = result[0].snippets[0].content;
   t.true(/boundary=---011000010111000001101001/.test(snippet));
   t.true(
     /formData: {'pet\[feedingSchedule\]': '{"time":"string","food":"string"}'}/.test(
@@ -252,8 +253,8 @@ test('Generate snippets with multiple content types', function (t) {
     'patch',
     ['node_request']
   );
-  t.equal(result.snippets.length, 2);
-  for (const snippet of result.snippets) {
+  t.equal(result[0].snippets.length, 2);
+  for (const snippet of result[0].snippets) {
     if (snippet.mimeType === 'application/json') {
       t.true(
         /headers: {'content-type': 'application\/json'}/.test(snippet.content)
@@ -282,7 +283,7 @@ test('Query Params Defined for all methods should be resolved', function (t) {
     'get',
     ['node_request']
   );
-  const snippet = result.snippets[0].content;
+  const snippet = result[0].snippets[0].content;
   t.true(/ {tags: 'dog,cat', limit: '10'}/.test(snippet));
   t.false(/SOME_INTEGER_VALUE/.test(snippet));
   t.end();
@@ -295,7 +296,7 @@ test('Query Params Defined for all methods are overriden by method definitions',
     'get',
     ['node_request']
   );
-  const snippet = result.snippets[0].content;
+  const snippet = result[0].snippets[0].content;
   t.true(/ qs: {id: '1,2'}/.test(snippet));
   t.end();
 });
@@ -307,7 +308,7 @@ test('Snippet for Get with no parameters should work', function (t) {
     'get',
     ['node_request']
   );
-  const snippet = result.snippets[0].content;
+  const snippet = result[0].snippets[0].content;
   t.false(/qs/.test(snippet));
   t.end();
 });
@@ -320,7 +321,7 @@ test('Testing the application/x-www-form-urlencoded example case', function (t) 
     'post',
     ['shell_curl']
   );
-  const snippet = result.snippets[0].content;
+  const snippet = result[0].snippets[0].content;
   t.match(snippet, /.*--data 'id=id\+example\+value'.*/);
   t.match(snippet, /.*--data 'secret=secret\+example\+value'.*/);
   t.end();


### PR DESCRIPTION
This introduces a solution for the issue [#62](https://github.com/ErikWittern/openapi-snippet/issues/62) and following [#64](https://github.com/ErikWittern/openapi-snippet/issues/64). 

Solution

This changes the response format of both `getSnippets` and `getEndpointSnippets`. As the response format is changed, test cases were also updated. I'm willing to brainstorm a simpler and straightforward solution but did this for an internal use-case.

**`getSnippets`**

Response will be an array of arrays rather than objects. Child array correspond to multiple servers. If one server, the length of child array will be one. Check the `url` in the response.

```
[
  [
    {
      "method": "GET",
      "url": "https://api.instagram.com/v1/users/{user-id}/relationship",
      "description": "Get information about a relationship to another user.",
      "resource": "relationship",
      "snippets": [
        {
          "id": "node",
          "mimeType": "application/json",  // Only set for methods with a request body
          "title": "Node + Native",
          "content": "var http = require(\"https\");\n\nvar options = {..."
        }
      ]
    },
    {
      "method": "GET",
      "url": "https://uat.api.instagram.com/v1/users/{user-id}/relationship",
      "description": "Get information about a relationship to another user in UAT.",
      "resource": "relationship",
      "snippets": [
        {
          "id": "node",
          "mimeType": "application/json",  // Only set for methods with a request body
          "title": "Node + Native",
          "content": "var http = require(\"https\");\n\nvar options = {..."
        }
      ]
    }
  ]
  //...
]
```

**`getEndpointSnippets`**

Response will be an array rather than an object. Array corresponds to multiple servers. If one server present, the length of array will be one. Check the `url` in the response.

```
[
  {
    method: 'GET',
    url: 'https://api.instagram.com/v1/locations/search',
    description: undefined,
    resource: 'search',
    snippets: [
      {
          "id": "node",
          "mimeType": "application/json",  // Only set for methods with a request body
          "title": "Node + Native",
          "content": "var http = require(\"https\");\n\nvar options = {..."
        }
    ]
  }
]
```