### PR TITLE
Parse required query params only

### DIFF
--- a/openapi-to-har.js
+++ b/openapi-to-har.js
@@ -269,7 +269,7 @@ const parseParametersToQuery = function (openApi, parameters, values) {
         }
       }
     }
-    if (typeof param.in !== 'undefined' && param.in.toLowerCase() === 'query') {
+    if (typeof param.in !== 'undefined' && param.in.toLowerCase() === 'query' && param.required) {
       // param.name is a safe key, because the spec defines
       // that name MUST be unique
       queryStrings[param.name] = getParameterValues(param, values);

--- a/test/instagram_swagger.json
+++ b/test/instagram_swagger.json
@@ -141,7 +141,7 @@
             "format": "int32",
             "in": "query",
             "name": "distance",
-            "required": false,
+            "required": true,
             "type": "integer"
           },
           {

--- a/test/parameter_example_swagger.json
+++ b/test/parameter_example_swagger.json
@@ -30,7 +30,7 @@
             "name": "tags",
             "in": "query",
             "description": "tags to filter by",
-            "required": false,
+            "required": true,
             "style": "form",
             "example": ["dog", "cat"],
             "schema": {
@@ -45,7 +45,7 @@
             "in": "query",
             "description": "maximum number of results to return",
             "example": 10,
-            "required": false,
+            "required": true,
             "schema": {
               "type": "integer",
               "format": "int32"
@@ -82,7 +82,7 @@
           "name": "tags",
           "in": "query",
           "description": "tags to filter by",
-          "required": false,
+          "required": true,
           "style": "form",
           "example": ["dog", "cat"],
           "schema": {
@@ -97,10 +97,20 @@
           "in": "query",
           "description": "maximum number of results to return",
           "example": 10,
-          "required": false,
+          "required": true,
           "schema": {
             "type": "integer",
             "format": "int32"
+          }
+        },
+        {
+          "name": "length",
+          "in": "query",
+          "description": "length property",
+          "example": "12",
+          "required": false,
+          "schema": {
+            "type": "integer"
           }
         }
       ],
@@ -152,7 +162,7 @@
             "name": "id",
             "in": "query",
             "description": "A comma-seperated list of species IDs",
-            "required": false,
+            "required": true,
             "example": [1, 2],
             "schema": {
               "type": "array",

--- a/test/parameter_schema_reference.json
+++ b/test/parameter_schema_reference.json
@@ -30,6 +30,7 @@
             "in": "query",
             "name": "pet",
             "description": "Pet to add to the store",
+            "required": true,
             "schema": {
               "$ref": "#/components/schemas/NewPet"
             }

--- a/test/test.js
+++ b/test/test.js
@@ -325,3 +325,17 @@ test('Testing the application/x-www-form-urlencoded example case', function (t) 
   t.match(snippet, /.*--data 'secret=secret\+example\+value'.*/);
   t.end();
 });
+
+test('Testing only required parameters are parsed', function (t) {
+  t.plan(2);
+  const result = OpenAPISnippets.getEndpointSnippets(
+    ParameterExampleReferenceAPI,
+    '/animals',
+    'get',
+    ['node_request']
+  );
+  const snippet = result.snippets[0].content;
+  t.true(/ {tags: 'dog,cat', limit: '10'}/.test(snippet));
+  t.false(/length: 12/.test(snippet));
+  t.end();
+});

--- a/test/watson_alchemy_language_swagger.json
+++ b/test/watson_alchemy_language_swagger.json
@@ -1184,7 +1184,7 @@
       "description": "Your API key",
       "in": "query",
       "name": "apikey",
-      "required": false,
+      "required": true,
       "type": "string"
     },
     "content_type": {
@@ -1586,7 +1586,7 @@
       "enum": [0, 1],
       "in": "query",
       "name": "showSourceText",
-      "required": false,
+      "required": true,
       "type": "integer"
     },
     "sourceText_formData": {


### PR DESCRIPTION
Add query param only if the parameter object has `required: true`