### PR TITLE
fix: default missing type to any type

### DIFF
--- a/openapi-to-har.js
+++ b/openapi-to-har.js
@@ -437,8 +437,20 @@ const getBaseUrl = function (openApi, path, method) {
  * @return {HarParameterObject[]} Array of objects describing the parameters in a given OpenAPI method or path
  */
 const getParameterValues = function (openApi, param, location, values) {
+  var type = (param.type || (param.schema && param.schema.type));
+
+  if (typeof type === 'undefined') {
+    type = "ANY"
+  } else if (typeof type !== 'string') {
+    // While this is an error and it'll get by the openapi-snippet
+    // generator, any openapi validator should flag this error where
+    // typeof type is not 'string'.
+    type = "ERROR"
+  } else {
+    type = type.toUpperCase()
+  }
   let value =
-    'SOME_' + (param.type || param.schema.type).toUpperCase() + '_VALUE';
+    'SOME_' + type + '_VALUE';
   if (location === 'path') {
     // then default to the original place holder value (e.b. '{id}')
     value = `{${param.name}}`;
@@ -500,10 +512,6 @@ const parseParametersToQuery = function (
         /^#/.test(param.schema['$ref'])
       ) {
         param.schema = resolveRef(openApi, param.schema['$ref']);
-        if (typeof param.schema.type === 'undefined') {
-          // many schemas don't have an explicit type
-          param.schema.type = 'object';
-        }
       }
     }
     if (

--- a/test/parameter_variations_swagger.json
+++ b/test/parameter_variations_swagger.json
@@ -67,6 +67,16 @@
                             "type": "integer",
                             "format": "int32"
                         }
+                    },
+                    {
+                        "name": "noType",
+                        "description": "can be any type",
+                        "in": "query"
+                    },
+                    {
+                        "name": "typeNotAString",
+                        "type": 35,
+                        "in": "query"
                     }
                 ],
                 "responses": {

--- a/test/test.js
+++ b/test/test.js
@@ -186,7 +186,7 @@ test('Parameters that are Schema References Are Dereferenced', function (t) {
     ['node_request']
   );
   const snippet = result.snippets[0].content;
-  t.true(/pet: 'SOME_OBJECT_VALUE'/.test(snippet));
+  t.true(/pet: 'SOME_ANY_VALUE'/.test(snippet));
   t.end();
 });
 
@@ -1712,5 +1712,31 @@ test('A reference in an examples object is resolved', function (t) {
 
   const snippet = result.snippets[0].content;
   t.match(snippet, /tags=dog%2Ccat/);
+  t.end();
+});
+
+test('A parameter without an explicit type is assigned the Any Type', function (t) {
+  const result = OpenAPISnippets.getEndpointSnippets(
+    ParameterVariationsAPI,
+    '/pets',
+    'get',
+    ['shell_curl']
+  );
+
+  const snippet = result.snippets[0].content;
+  t.match(snippet, /noType=SOME_ANY_VALUE/);
+  t.end();
+});
+
+test('A parameter with a type that is not a string value (like "boolean" or "object") is an error', function (t) {
+  const result = OpenAPISnippets.getEndpointSnippets(
+    ParameterVariationsAPI,
+    '/pets',
+    'get',
+    ['shell_curl']
+  );
+
+  const snippet = result.snippets[0].content;
+  t.match(snippet, /typeNotAString=SOME_ERROR_VALUE/);
   t.end();
 });


### PR DESCRIPTION
Primarily this is to fix the TypeError that is thrown if a parameter
is missing any type information. Such an error makes it hard to debug
your spec:

```
/openapi-snippet/openapi-to-har.js:441
 'SOME_' + (param.type || param.schema.type).toUpperCase() + '_VALUE';
                                             ^
TypeError: Cannot read properties of undefined (reading 'type')
    at getParameterValues (/Users/cwelchmi/emu/metasys-rest-api/node_modules/openapi-snippet/openapi-to-har.js:441:43)
```

Per the spec if no type is given then the type defaults to the Any Type:
https://swagger.io/docs/specification/data-models/data-types/#any

This commit removes a check that explicitly sets any undefined
type to object, instead leaving it blank. Then where type checking
is done it adds support for missing types.

One existing test was expecting SOME_OBJECT_TYPE because of a missing
type, this test was corrected to look for SOME_ANY_TYPE. An additional
test was added to explicitly state that missing types are to be
considered Any Type.

In addition a fix was made that if the value of a type field is not
a string, then the parameter value SOME_ERROR_TYPE is generated. This
allows the snippet generator to run without error, but presumably
in some workflow the openapi validator will catch the spec error.

Fixes #89

> **Note** While I cannot find an explicit statement about Any Type in
> the OpenApi spec, any openapi validators I used (like SwaggerHub)
> act as if the type is Any Type and does not act as if the type is 
> `"object"`. This is likely because in the absence of a constraint
> in OpenAPI spec, no constraint is assumed.