### PR TITLE
Support providing parameter values and post body values

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,15 +20,19 @@ const HTTPSnippet = require('httpsnippet');
  * @param {string} method   HTTP method identifying endpoint, e.g., 'get'
  * @param {array} targets   List of languages to create snippets in, e.g,
  *                          ['cURL', 'Node']
- * @param {object} values   Optional: Values for the query parameters if present
+ * @param {object} parameterValues   Optional: Values for the parameters if present
+ * @param {object} requestBodyValues Optional: Values for the request body if present
  */
-const getEndpointSnippets = function (openApi, path, method, targets, values) {
+const getEndpointSnippets = function (openApi, path, method, targets, parameterValues, requestBodyValues) {
   // if optional parameter is not provided, set it to empty object
-  if (typeof values === 'undefined') {
-    values = {};
+  if (typeof parameterValues === 'undefined') {
+    parameterValues = {};
+  }
+  if (typeof requestBodyValues === 'undefined') {
+    requestBodyValues = {};
   }
 
-  const hars = OpenAPIToHar.getEndpoint(openApi, path, method, values);
+  const hars = OpenAPIToHar.getEndpoint(openApi, path, method, parameterValues, requestBodyValues);
 
   const snippets = [];
   for (const har of hars) {

--- a/test/test.js
+++ b/test/test.js
@@ -121,6 +121,23 @@ test('Testing optionally provided parameter values', function (t) {
   t.false(/not-a-query-param/.test(result.snippets[0].content));
 });
 
+test('Testing optionally provided parameter values in path and query', function (t) {
+  t.plan(2);
+  // checks the 'Pages' schema...
+  const result = OpenAPISnippets.getEndpointSnippets(
+    InstagramOpenAPI,
+    '/geographies/{geo-id}/media/recent',
+    'get',
+    ['node_request'],
+    {
+      'geo-id': 'geo-id-xxx',
+      'count': 1024,
+    }
+  );
+  t.true(/geo-id-xxx/.test(result.snippets[0].content));
+  t.true(/1024/.test(result.snippets[0].content));
+});
+
 test('Testing the case when default is present but a value is provided, use the provided value', function (t) {
   t.plan(2);
   // checks the 'Pages' schema...
@@ -209,12 +226,17 @@ test('Generate snippet with multipart/form-data', function (t) {
     FormDataExampleReferenceAPI,
     '/pets',
     'patch',
-    ['node_request']
+    ['node_request'],
+    {},
+    {
+      'pet[name]': 'happy',
+      'pet[tag]': 'puppy'
+    }
   );
   const snippet = result.snippets[0].content;
   t.true(/boundary=---011000010111000001101001/.test(snippet));
   t.true(
-    /formData: {'pet\[name\]': 'string', 'pet\[tag\]': 'string'}/.test(snippet)
+    /formData: {'pet\[name\]': 'happy', 'pet\[tag\]': 'puppy'}/.test(snippet)
   );
   t.end();
 });


### PR DESCRIPTION
The project is awesome!
The pull request want to make the project more perfect by providing the following patches:

* `getEndpointSnippets` supports an optional `values` parameter to provide query parameters. However other 3 types of parameters, such as header, path and cookie are not supported. The pull request extends the `values` parameter to support other 3 types of parameters.
* Considering `postBody` is another commonly used way to pass parameters, the pull request support the set the postBody values as well.
* In addition, the pull request updates the `test.js` to cover the patches and all tests has been passed.